### PR TITLE
replace getColumnName() with getColumnLabel() 

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -56,7 +56,7 @@ public class JdbcInputConnection
         ImmutableList.Builder<JdbcColumn> columns = ImmutableList.builder();
         for (int i=0; i < metadata.getColumnCount(); i++) {
             int index = i + 1;  // JDBC column index begins from 1
-            String name = metadata.getColumnName(index);
+            String name = metadata.getColumnLabel(index);
             String typeName = metadata.getColumnTypeName(index);
             int sqlType = metadata.getColumnType(index);
             //String scale = metadata.getScale(index)


### PR DESCRIPTION
> replace getColumnName() with getColumnLabel() , as getColumnName() of mysql-connector returns original column name.

    query: select name as name2 from t

mysql
- getColumnName() -> "name"
- getColumnLabel() -> "name2"

postgresql
- getColumnName() -> "name2"
- getColumnLabel() -> "name2"
