### PR TITLE
use getColumnLabel to know column name

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -56,7 +56,7 @@ public class JdbcInputConnection
         ImmutableList.Builder<JdbcColumn> columns = ImmutableList.builder();
         for (int i=0; i < metadata.getColumnCount(); i++) {
             int index = i + 1;  // JDBC column index begins from 1
-            String name = metadata.getColumnName(index);
+            String name = metadata.getColumnLabel(index);
             String typeName = metadata.getColumnTypeName(index);
             int sqlType = metadata.getColumnType(index);
             //String scale = metadata.getScale(index)


### PR DESCRIPTION
When we config raw query  *select x as x_name, y as y_name*  in config file, column name will be 'x' and 'y' instead of 'x_name', 'y_name'.
This PR will resolve this problem by using method *getColumnLabel*.

Can you review & merge this PR if this behavior is correct?
