### PR TITLE
options: option accepts non-string YAML literals such as 'true', 'false', and integers

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -45,7 +45,7 @@ public abstract class AbstractJdbcInputPlugin
     {
         @Config("options")
         @ConfigDefault("{}")
-        public Properties getOptions();
+        public ToStringMap getOptions();
 
         @Config("table")
         @ConfigDefault("null")

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToString.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToString.java
@@ -1,0 +1,54 @@
+package org.embulk.input.jdbc;
+
+import com.google.common.base.Optional;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+public class ToString
+{
+    private final String string;
+
+    public ToString(String string)
+    {
+        this.string = string;
+    }
+
+    @JsonCreator
+    ToString(Optional<JsonNode> option) throws JsonMappingException
+    {
+        JsonNode node = option.or(NullNode.getInstance());
+        if (node.isTextual()) {
+            this.string = node.textValue();
+        } else if (node.isValueNode()) {
+            this.string = node.toString();
+        } else {
+            throw new JsonMappingException(String.format("Arrays and objects are invalid: '%s'", node));
+        }
+    }
+
+    @Override
+    public boolean equals(Object obj)
+    {
+        if (!(obj instanceof ToString)) {
+            return false;
+        }
+        ToString o = (ToString) obj;
+        return string.equals(o.string);
+    }
+
+    @Override
+    public int hashCode()
+    {
+        return string.hashCode();
+    }
+
+    @JsonValue
+    @Override
+    public String toString()
+    {
+        return string;
+    }
+}

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
@@ -1,0 +1,36 @@
+package org.embulk.input.jdbc;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.Properties;
+import com.google.common.base.Function;
+import com.google.common.collect.Maps;
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+// TODO copied from embulk-output-jdbc. Move this class to embulk-core spi.unit.
+public class ToStringMap
+        extends HashMap<String, String>
+{
+    @JsonCreator
+    ToStringMap(Map<String, ToString> map)
+    {
+        super(Maps.transformValues(map, new Function<ToString, String>() {
+            public String apply(ToString value)
+            {
+                if (value == null) {
+                    return "null";
+                } else {
+                    return value.toString();
+                }
+            }
+        }));
+    }
+
+    public Properties toProperties()
+    {
+        Properties props = new Properties();
+        props.putAll(this);
+        return props;
+    }
+}


### PR DESCRIPTION
This doesn't work:

```
options: {abc: true}
```

But this works:

```
options: {abc: "true"}
```

This is because `true` is boolean in YAML and jackson doesn't convert it to string automatically.

This pull-request fixes this unexpected behavior.
