### PR TITLE
Add connect_timeout and socket_timeout to config

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
 - **password**: database login password (string, default: optional)
 - **schema**: destination schema name (string, default: use the default schema)
 - **fetch_rows**: number of rows to fetch one time (integer, default: 10000)
+- **connect_timeout**: not supported.
+- **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -97,6 +97,14 @@ public abstract class AbstractJdbcInputPlugin
         //@ConfigDefault("null")
         //public Optional<Integer> getLimitRows();
 
+        @Config("connect_timeout")
+        @ConfigDefault("300")
+        public int getConnectTimeout();
+
+        @Config("socket_timeout")
+        @ConfigDefault("1800")
+        public int getSocketTimeout();
+
         @Config("fetch_rows")
         @ConfigDefault("10000")
         // TODO set minimum number

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -246,7 +246,7 @@ public abstract class AbstractJdbcInputPlugin
             List<ColumnGetter> getters = newColumnGetters(task, querySchema, pageBuilder);
 
             try (JdbcInputConnection con = newConnection(task)) {
-                try (BatchSelect cursor = con.newSelectCursor(getQuery(task, con), task.getFetchRows())) {
+                try (BatchSelect cursor = con.newSelectCursor(getQuery(task, con), task.getFetchRows(), task.getSocketTimeout())) {
                     while (true) {
                         // TODO run fetch() in another thread asynchronously
                         // TODO retry fetch() if it failed (maybe order_by is required and unique_column(s) option is also required)

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -66,16 +66,17 @@ public class JdbcInputConnection
         return new JdbcSchema(columns.build());
     }
 
-    public BatchSelect newSelectCursor(String query, int fetchRows) throws SQLException
+    public BatchSelect newSelectCursor(String query, int fetchRows, int queryTimeout) throws SQLException
     {
-        return newBatchSelect(query, fetchRows);
+        return newBatchSelect(query, fetchRows, queryTimeout);
     }
 
-    protected BatchSelect newBatchSelect(String query, int fetchRows) throws SQLException
+    protected BatchSelect newBatchSelect(String query, int fetchRows, int queryTimeout) throws SQLException
     {
         logger.info("SQL: " + query);
         PreparedStatement stmt = connection.prepareStatement(query);
         stmt.setFetchSize(fetchRows);
+        stmt.setQueryTimeout(queryTimeout);
         return new SingleSelect(stmt);
     }
 

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -30,6 +30,8 @@ MySQL input plugins for Embulk loads records from MySQL.
   - If this value is set to -1:
     - It uses a client-side built statement and fetches all rows at once. This may cause OutOfMemoryError.
     - Internally, `useCursorFetch=false` is used and `java.sql.Statement.setFetchSize` is not set.
+- **connect_timeout**: timeout for socket connect. 0 means no timeout. (integer (seconds), default: 300)
+- **socket_timeout**: timeout on network socket operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -4,7 +4,6 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import com.google.common.base.Throwables;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -58,8 +57,8 @@ public class MySQLInputPlugin
 
         props.setProperty("useCompression", "true");
 
-        props.setProperty("connectTimeout", "300000"); // milliseconds
-        props.setProperty("socketTimeout", "1800000"); // smillieconds
+        props.setProperty("connectTimeout", String.valueOf(t.getConnectTimeout() * 1000)); // milliseconds
+        props.setProperty("socketTimeout", String.valueOf(t.getSocketTimeout() * 1000)); // milliseconds
 
         // Enable keepalive based on tcp_keepalive_time, tcp_keepalive_intvl and tcp_keepalive_probes kernel parameters.
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -16,7 +16,7 @@ public class MySQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(String select, int fetchRows) throws SQLException
+    protected BatchSelect newBatchSelect(String select, int fetchRows, int queryTimeout) throws SQLException
     {
         logger.info("SQL: " + select);
         PreparedStatement stmt = connection.prepareStatement(select, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
@@ -30,6 +30,7 @@ public class MySQLInputConnection
             // useCursorFetch=true is enabled. MySQL creates temporary table and uses multiple select statements to fetch rows.
             stmt.setFetchSize(fetchRows);
         }
+        // Because socketTimeout is set in Connection, don't need to set quertyTimeout.
         return new SingleSelect(stmt);
     }
 }

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -23,6 +23,8 @@ Oracle input plugins for Embulk loads records from Oracle.
   - **select**: comma-separated list of columns to select (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
+- **socket_timeout**: timeout for socket read operations. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -78,6 +78,8 @@ public class OracleInputPlugin
         Properties props = new Properties();
         props.setProperty("user", oracleTask.getUser());
         props.setProperty("password", oracleTask.getPassword());
+        props.setProperty("oracle.net.CONNECT_TIMEOUT", String.valueOf(oracleTask.getConnectTimeout() * 1000)); // milliseconds
+        props.setProperty("oracle.jdbc.ReadTimeout", String.valueOf(oracleTask.getSocketTimeout() * 1000)); // milliseconds
         props.putAll(oracleTask.getOptions());
 
         if (oracleTask.getDriverPath().isPresent()) {

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -16,6 +16,8 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
+- **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -4,7 +4,6 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import com.google.common.base.Throwables;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -57,8 +56,8 @@ public class PostgreSQLInputPlugin
         Properties props = new Properties();
         props.setProperty("user", t.getUser());
         props.setProperty("password", t.getPassword());
-        props.setProperty("loginTimeout",   "300"); // seconds
-        props.setProperty("socketTimeout", "1800"); // seconds
+        props.setProperty("loginTimeout", String.valueOf(t.getConnectTimeout())); // seconds
+        props.setProperty("socketTimeout", String.valueOf(t.getSocketTimeout())); // seconds
 
         // Enable keepalive based on tcp_keepalive_time, tcp_keepalive_intvl and tcp_keepalive_probes kernel parameters.
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
@@ -20,11 +20,12 @@ public class PostgreSQLInputConnection
     }
 
     @Override
-    protected CursorSelect newBatchSelect(String select, int fetchRows) throws SQLException
+    protected CursorSelect newBatchSelect(String select, int fetchRows, int queryTimeout) throws SQLException
     {
         executeUpdate("DECLARE cur NO SCROLL CURSOR FOR "+select);
 
         String fetchSql = "FETCH FORWARD "+fetchRows+" FROM cur";
+        // Because socketTimeout is set in Connection, don't need to set quertyTimeout.
         return new CursorSelect(fetchSql, connection.prepareStatement(fetchSql));
     }
 

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -17,6 +17,8 @@ Redshift input plugins for Embulk loads records from Redshift.
 - **schema**: destination schema name (string, default: "public")
 - **where**: WHERE condition to filter the rows (string, default: no-condition)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
+- **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
@@ -4,10 +4,10 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import com.google.common.base.Throwables;
+
+
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
 
@@ -58,8 +58,8 @@ public class RedshiftInputPlugin
         Properties props = new Properties();
         props.setProperty("user", t.getUser());
         props.setProperty("password", t.getPassword());
-        props.setProperty("loginTimeout",   "300"); // seconds
-        props.setProperty("socketTimeout", "1800"); // seconds
+        props.setProperty("loginTimeout", String.valueOf(t.getConnectTimeout())); // seconds
+        props.setProperty("socketTimeout", String.valueOf(t.getSocketTimeout())); // seconds
 
         // Enable keepalive based on tcp_keepalive_time, tcp_keepalive_intvl and tcp_keepalive_probes kernel parameters.
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -29,6 +29,8 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **select**: comma-separated list of columns to select (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **connect_timeout**: timeout for the driver to connect. 0 means the default of SQL Server (15 by default). (integer (seconds), default: 300)
+- **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -118,6 +118,7 @@ public class SQLServerInputPlugin
         if (sqlServerTask.getPassword().isPresent()) {
             props.setProperty("password", sqlServerTask.getPassword().get());
         }
+        props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
         props.putAll(sqlServerTask.getOptions());
 
         if (sqlServerTask.getDriverPath().isPresent()) {


### PR DESCRIPTION
- Add connect_timeout and socket_timeout to config.
- MySQLInputPlugin, PostgreSQLInputPlugin and RedshiftInputPlugin had fixed timeout values. Now they get timeout values from config.
- embulk-input-oracle and embulk-input-sqlserver didn't support timeout (see #16 ). Now they support.
- embulk-input-jdbc only support socket_timeout (actually query timeout) using standard JDBC driver method (`Statement#setQueryTimeout`).It doesn't support connect_timeout because the standard JDBC driver method for it (`DriverManager#setLoginTimeout`) is static and it may affect other modules.