### PR TITLE
Add some SSL options and update connector to latest.

### DIFF
--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -18,6 +18,8 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
+- **ssl**: Connect using SSL? (boolean, default: false)
+- **sslfactory**: A class name to use as the SSLSocketFactory when establishing a SSL connection. [See also](https://jdbc.postgresql.org/documentation/head/ssl-factory.html) (string, default: null)
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':embulk-input-jdbc')
 
-    compile 'org.postgresql:postgresql:9.4-1205-jdbc42'
+    compile 'org.postgresql:postgresql:9.4-1205-jdbc41'
 
     testCompile project(':embulk-input-jdbc').sourceSets.test.output
 }

--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':embulk-input-jdbc')
 
-    compile 'org.postgresql:postgresql:9.4-1200-jdbc41'
+    compile 'org.postgresql:postgresql:9.4-1205-jdbc42'
 
     testCompile project(':embulk-input-jdbc').sourceSets.test.output
 }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -4,6 +4,8 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+
+import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -37,6 +39,14 @@ public class PostgreSQLInputPlugin
         @Config("schema")
         @ConfigDefault("\"public\"")
         public String getSchema();
+
+        @Config("ssl")
+        @ConfigDefault("false")
+        public boolean getSsl();
+
+        @Config("sslfactory")
+        @ConfigDefault("null")
+        public Optional<String> getSslfactory();
     }
 
     @Override
@@ -63,16 +73,12 @@ public class PostgreSQLInputPlugin
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.
         props.setProperty("tcpKeepAlive", "true");
 
-        // TODO
-        //switch t.getSssl() {
-        //when "disable":
-        //    break;
-        //when "enable":
-        //    props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
-        //when "verify":
-        //    props.setProperty("ssl", "true");
-        //    break;
-        //}
+        if(t.getSsl()) {
+            props.setProperty("ssl", "true");
+        }
+        if(t.getSslfactory().isPresent()) {
+            props.setProperty("sslfactory", t.getSslfactory().get());
+        }
 
         props.putAll(t.getOptions());
 


### PR DESCRIPTION
I want to use this plugin for [Heroku Postgres](https://www.heroku.com/postgres).
However, some SSL options are not implemented. ([ref](https://devcenter.heroku.com/articles/connecting-to-relational-databases-on-heroku-with-java#connecting-to-a-database-remotely))
In addition, current Postgres JDBC Driver has the [SSL issue](https://github.com/pgjdbc/pgjdbc/issues/259).