### PR TITLE
Add ssl: option to postgresql

### DIFF
--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -18,6 +18,7 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
+- **ssl**: enables SSL. data will be encrypted but CA or certification will not be verified (boolean, default: false)
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -37,6 +37,10 @@ public class PostgreSQLInputPlugin
         @Config("schema")
         @ConfigDefault("\"public\"")
         public String getSchema();
+
+        @Config("ssl")
+        @ConfigDefault("false")
+        public boolean getSsl();
     }
 
     @Override
@@ -63,16 +67,13 @@ public class PostgreSQLInputPlugin
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.
         props.setProperty("tcpKeepAlive", "true");
 
-        // TODO
-        //switch t.getSssl() {
-        //when "disable":
-        //    break;
-        //when "enable":
-        //    props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
-        //when "verify":
-        //    props.setProperty("ssl", "true");
-        //    break;
-        //}
+        if (t.getSsl()) {
+            // TODO add ssl_verify (boolean) option to allow users to verify certification.
+            //      see embulk-input-ftp for SSL implementation.
+            props.setProperty("ssl", "true");
+            props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
+        }
+        // setting ssl=false enables SSL. See org.postgresql.core.v3.openConnectionImpl.
 
         props.putAll(t.getOptions());
 


### PR DESCRIPTION
Setting ssl: true sets ssl=true and sslfactory=org.postgresql.ssl.NonValidatingFactory
JDBC options.