### PR TITLE
ConfigException if setupTask throws SQLException

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -149,7 +149,7 @@ public abstract class AbstractJdbcInputPlugin
         try (JdbcInputConnection con = newConnection(task)) {
             schema = setupTask(con, task);
         } catch (SQLException ex) {
-            throw Throwables.propagate(ex);
+            throw new ConfigException(ex);
         }
 
         return buildNextConfigDiff(task, control.run(task.dump(), schema, 1));


### PR DESCRIPTION
JdbcInputPlugin should throw ConfigException if setupTask throws SQLException because the exception is thrown by an user's wrong configuration.

fix #23 and #28