### PR TITLE
Change timing to log SQL

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -158,7 +158,9 @@ public abstract class AbstractJdbcInputPlugin
     private Schema setupTask(JdbcInputConnection con, PluginTask task) throws SQLException
     {
         // build SELECT query and gets schema of its result
-        JdbcSchema querySchema = con.getSchemaOfQuery(getQuery(task, con));
+    	String query = getQuery(task, con);
+        logger.info("SQL: " + query);
+        JdbcSchema querySchema = con.getSchemaOfQuery(query);
         task.setQuerySchema(querySchema);
 
         // validate column_options

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -73,7 +73,6 @@ public class JdbcInputConnection
 
     protected BatchSelect newBatchSelect(String query, int fetchRows, int queryTimeout) throws SQLException
     {
-        logger.info("SQL: " + query);
         PreparedStatement stmt = connection.prepareStatement(query);
         stmt.setFetchSize(fetchRows);
         stmt.setQueryTimeout(queryTimeout);


### PR DESCRIPTION
The query SQL is logged at `run` method, but the SQL is used at `transaction` method before `run`.
So if the SQL fails at `transaction` method, we won't be able to know the SQL.
I've moved SQL logging from `run` method to `transaction` method.