### PR TITLE
Support json type

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -166,7 +166,7 @@ public abstract class AbstractJdbcInputPlugin
         // validate column_options
         newColumnGetters(task, querySchema, null);
 
-        ColumnGetterFactory factory = new ColumnGetterFactory(null, task.getDefaultTimeZone());
+        ColumnGetterFactory factory = newColumnGetterFactory(null, task.getDefaultTimeZone());
         ImmutableList.Builder<Column> columns = ImmutableList.builder();
         for (int i = 0; i < querySchema.getCount(); i++) {
             JdbcColumn column = querySchema.getColumn(i);
@@ -273,10 +273,15 @@ public abstract class AbstractJdbcInputPlugin
         return report;
     }
 
+    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    {
+        return new ColumnGetterFactory(pageBuilder, dateTimeZone);
+    }
+
     private List<ColumnGetter> newColumnGetters(PluginTask task, JdbcSchema querySchema, PageBuilder pageBuilder)
             throws SQLException
     {
-        ColumnGetterFactory factory = new ColumnGetterFactory(pageBuilder, task.getDefaultTimeZone());
+        ColumnGetterFactory factory = newColumnGetterFactory(pageBuilder, task.getDefaultTimeZone());
         ImmutableList.Builder<ColumnGetter> getters = ImmutableList.builder();
         for (JdbcColumn c : querySchema.getColumns()) {
             JdbcColumnOption columnOption = columnOptionOf(task.getColumnOptions(), c);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
@@ -57,9 +57,7 @@ public abstract class AbstractColumnGetter implements ColumnGetter, ColumnVisito
     }
 
     @Override
-    public void jsonColumn(Column column) {
-        throw new UnsupportedOperationException("This plugin doesn't support json type. Please try to upgrade version of the plugin using 'embulk gem update' command. If the latest version still doesn't support json type, please contact plugin developers, or change configuration of input plugin not to use json type.");
-    }
+    public void jsonColumn(Column column) { to.setNull(column); }
 
     @Override
     public void timestampColumn(Column column)

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -43,6 +43,8 @@ public class ColumnGetterFactory
             return new BooleanColumnGetter(to, toType);
         case "string":
             return new StringColumnGetter(to, toType);
+        case "json":
+            return new JsonColumnGetter(to, toType);
         case "date":
             return new DateColumnGetter(to, toType, newTimestampFormatter(option, DateColumnGetter.DEFAULT_FORMAT));
         case "time":
@@ -56,7 +58,7 @@ public class ColumnGetterFactory
         }
     }
 
-    private String sqlTypeToValueType(JdbcColumn column, int sqlType)
+    protected String sqlTypeToValueType(JdbcColumn column, int sqlType)
     {
         switch(sqlType) {
         // getLong

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/JsonColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/JsonColumnGetter.java
@@ -2,6 +2,8 @@ package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import org.embulk.input.jdbc.getter.AbstractColumnGetter;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.json.JsonParseException;
@@ -10,14 +12,14 @@ import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 import org.msgpack.value.Value;
 
-public class StringColumnGetter
+public class JsonColumnGetter
         extends AbstractColumnGetter
 {
     final JsonParser jsonParser = new JsonParser();
 
     private String value;
 
-    public StringColumnGetter(PageBuilder to, Type toType)
+    public JsonColumnGetter(PageBuilder to, Type toType)
     {
         super(to, toType);
     }
@@ -31,33 +33,7 @@ public class StringColumnGetter
     @Override
     protected Type getDefaultToType()
     {
-        return Types.STRING;
-    }
-
-    @Override
-    public void longColumn(Column column)
-    {
-        long l;
-        try {
-            l = Long.parseLong(value);
-        } catch (NumberFormatException e) {
-            super.longColumn(column);
-            return;
-        }
-        to.setLong(column, l);
-    }
-
-    @Override
-    public void doubleColumn(Column column)
-    {
-        double d;
-        try {
-            d = Double.parseDouble(value);
-        } catch (NumberFormatException e) {
-            super.doubleColumn(column);
-            return;
-        }
-        to.setDouble(column, d);
+        return Types.JSON;
     }
 
     @Override

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
@@ -4,12 +4,17 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonParseException;
+import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.msgpack.value.Value;
 
 public class StringColumnGetter
         extends AbstractColumnGetter
 {
+    private static final JsonParser jsonParser = new JsonParser();
+
     private String value;
 
     public StringColumnGetter(PageBuilder to, Type toType)
@@ -53,6 +58,19 @@ public class StringColumnGetter
             return;
         }
         to.setDouble(column, d);
+    }
+
+    @Override
+    public void jsonColumn(Column column)
+    {
+        Value v;
+        try {
+            v = jsonParser.parse(value);
+        } catch (JsonParseException e) {
+            super.jsonColumn(column);
+            return;
+        }
+        to.setJson(column, v);
     }
 
     @Override

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -7,7 +7,11 @@ import java.sql.SQLException;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
+import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
+import org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
 
 public class PostgreSQLInputPlugin
         extends AbstractJdbcInputPlugin
@@ -87,5 +91,11 @@ public class PostgreSQLInputPlugin
                 con.close();
             }
         }
+    }
+
+    @Override
+    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    {
+        return new PostgreSQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }
 }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -1,0 +1,24 @@
+package org.embulk.input.postgresql.getter;
+
+import org.embulk.input.jdbc.JdbcColumn;
+import org.embulk.input.jdbc.getter.ColumnGetterFactory;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
+
+public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
+{
+    public PostgreSQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    {
+        super(to, defaultTimeZone);
+    }
+
+    @Override
+    protected String sqlTypeToValueType(JdbcColumn column, int sqlType)
+    {
+        if (column.getTypeName().equals("json") || column.getTypeName().equals("jsonb")) {
+            return "json";
+        } else {
+            return super.sqlTypeToValueType(column, sqlType);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds json type support.

- `string` can convert to `json`
- other type cannot convert to `json`, set `null`
- default type of PostgreSQL json(jsonb) column is `json`
  - get value as string from DB, and parse it.
- parse JSON string by JsonParser class of embulk-core

But I checked on only MySQL and PostgreSQL.
I cannot ready redshift, oracle, and sqlserver.
Would you confirm this PR on them?