### PR TITLE
Enabled to execute SQL after SELECT

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 
 
@@ -108,6 +109,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -120,9 +120,9 @@ public abstract class AbstractJdbcInputPlugin
         @ConfigDefault("\"UTC\"")
         public DateTimeZone getDefaultTimeZone();
 
-        @Config("after_execute")
+        @Config("after_select")
         @ConfigDefault("null")
-        public Optional<String> getAfterExecute();
+        public Optional<String> getAfterSelect();
 
         public JdbcSchema getQuerySchema();
         public void setQuerySchema(JdbcSchema schema);
@@ -263,8 +263,8 @@ public abstract class AbstractJdbcInputPlugin
                     }
                 }
 
-                if (task.getAfterExecute().isPresent()) {
-                    con.executeUpdate(task.getAfterExecute().get());
+                if (task.getAfterSelect().isPresent()) {
+                    con.executeUpdate(task.getAfterSelect().get());
                 }
             }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -265,6 +265,7 @@ public abstract class AbstractJdbcInputPlugin
 
                 if (task.getAfterSelect().isPresent()) {
                     con.executeUpdate(task.getAfterSelect().get());
+                    con.connection.commit();
                 }
             }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -120,6 +120,10 @@ public abstract class AbstractJdbcInputPlugin
         @ConfigDefault("\"UTC\"")
         public DateTimeZone getDefaultTimeZone();
 
+        @Config("after_execute")
+        @ConfigDefault("null")
+        public Optional<String> getAfterExecute();
+
         public JdbcSchema getQuerySchema();
         public void setQuerySchema(JdbcSchema schema);
 
@@ -158,7 +162,7 @@ public abstract class AbstractJdbcInputPlugin
     private Schema setupTask(JdbcInputConnection con, PluginTask task) throws SQLException
     {
         // build SELECT query and gets schema of its result
-    	String query = getQuery(task, con);
+        String query = getQuery(task, con);
         logger.info("SQL: " + query);
         JdbcSchema querySchema = con.getSchemaOfQuery(query);
         task.setQuerySchema(querySchema);
@@ -257,6 +261,10 @@ public abstract class AbstractJdbcInputPlugin
                             break;
                         }
                     }
+                }
+
+                if (task.getAfterExecute().isPresent()) {
+                    con.executeUpdate(task.getAfterExecute().get());
                 }
             }
 

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -43,6 +43,7 @@ MySQL input plugins for Embulk loads records from MySQL.
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 ## Example
 
@@ -89,6 +90,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -37,6 +37,7 @@ Oracle input plugins for Embulk loads records from Oracle.
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 ## Example
 
@@ -86,6 +87,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -36,6 +36,7 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 ## Example
 
@@ -82,6 +83,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -36,6 +36,7 @@ Redshift input plugins for Embulk loads records from Redshift.
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 ## Example
 
@@ -82,6 +83,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -42,6 +42,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **timestamp_format**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted by this timestamp_format. And if the embulk type is `timestamp`, this timestamp_format may be used in the output plugin. For example, stdout plugin use the timestamp_format, but *csv formatter plugin doesn't use*. (string, default : `%Y-%m-%d` for `date`, `%H:%M:%S` for `time`, `%Y-%m-%d %H:%M:%S` for `timestamp`)
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
+- **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 ## Example
 
@@ -94,6 +95,7 @@ in:
   column_options:
     col1: {type: long}
     col3: {type: string, timestamp_format: "%Y/%m/%d", timezone: "+0900"}
+  after_select: "update my_table set col5 = '1' where col4 != 'a'"
 
 ```
 


### PR DESCRIPTION
Added `after_select` property in order to execute SQL after SELECT in the same transaction.

ex)
(1) begin transaction
(2) select * from some_table where update_date < '2016-01-01'
(3) output the result of (2) to csv file
(4) delete from some_table where update_date < '2016-01-01'
(5) commit