### PR TITLE
[WIP] Upgrade gradle and jruby-gradle for fix #42

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 
 plugins {
     id 'com.jfrog.bintray' version '1.6'
-    id 'com.github.jruby-gradle.base' version '0.1.5'
+    id 'com.github.jruby-gradle.base' version '1.2.1'
     id 'java'
     id 'checkstyle'
 }
@@ -126,7 +126,7 @@ subprojects {
 
     task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath']) {
         jrubyArgs '-rrubygems/gem_runner', "-eGem::GemRunner.new.run(ARGV)", 'build'
-        script "${project.projectDir.absolutePath}/build/gemspec"
+        scriptArgs "${project.projectDir.absolutePath}/build/gemspec"
         doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "${parent.projectDir}/pkg") }
     }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.12-bin.zip


### PR DESCRIPTION


After upgradle gradle-jruby to 1.2.1 and execute `gradlew gem` I got the following error.

Maybe this issue related. https://github.com/jruby-gradle/jruby-gradle-plugin/issues/152
That's why I modified ``script`` to ``scriptArgs``

```
gradlew gem
...
Download https://repo1.maven.org/maven2/org/jruby/jruby-complete/9.0.5.0/jruby-complete-9.0.5.0.jar
ERROR:  While executing gem ... (OptionParser::InvalidOption)
    invalid option: -S
:embulk-input-jdbc:gem FAILED

FAILURE: Build failed with an exception.

* Where:
Build file '/path/to/embulk/embulk-input-jdbc/build.gradle' line: 130

* What went wrong:
Execution failed for task ':embulk-input-jdbc:gem'.
> Warning: Could not find file /path/to/embulk/embulk-input-jdbc/embulk-input-jdbc/embulk-input-jdbc-0.6.4.gem to copy.

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output.

BUILD FAILED

Total time: 8 mins 51.789 secs
```

``gradlew gem`` exeucte following command.
I found ``-S`` options.

```
java -Dfile.encoding=UTF-8 -Duser.country=JP -Duser.language=ja \
     -Duser.variant -cp /path/to/home/.gradle/caches/modules-2/files-2.1/org.jruby/jruby-complete/9.0.5.0/a5f1d5e8945a08ac9da8f7f528c513c60445eaeb/jruby-complete-9.0.5.0.jar \
     org.jruby.Main \
    -I /path/to/home/OpenProjects/embulk/embulk-input-jdbc/embulk-input-jdbc/build/tmp/jrubyExec/gems/jar-dependencies-0.1.15/lib \
    -rjars/setup -rrubygems/gem_runner -eGem::GemRunner.new.run(ARGV) \
    build \
    -S /path/to/home/OpenProjects/embulk/embulk-input-jdbc/embulk-input-jdbc/build/gemspec
    ^^^
```


