### PR TITLE
Support hstore column for PostgreSQL

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -31,7 +31,7 @@ public class ColumnGetterFactory
         return newColumnGetter(column, option, option.getValueType());
     }
 
-    protected ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
+    private ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
     {
         Type toType = getToType(option);
         switch(valueType) {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -16,7 +16,7 @@ import org.joda.time.DateTimeZone;
 
 public class ColumnGetterFactory
 {
-    private final PageBuilder to;
+    protected final PageBuilder to;
     private final DateTimeZone defaultTimeZone;
     private final Map<Integer, String> jdbcTypes = getAllJDBCTypes();
 
@@ -31,7 +31,7 @@ public class ColumnGetterFactory
         return newColumnGetter(column, option, option.getValueType());
     }
 
-    private ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
+    protected ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
     {
         Type toType = getToType(option);
         switch(valueType) {
@@ -162,7 +162,7 @@ public class ColumnGetterFactory
         }
     }
 
-    private Type getToType(JdbcColumnOption option)
+    protected Type getToType(JdbcColumnOption option)
     {
         if (!option.getType().isPresent()) {
             return null;

--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -3,5 +3,6 @@ dependencies {
 
     compile 'org.postgresql:postgresql:9.4-1205-jdbc41'
 
+    testCompile 'org.embulk:embulk-standards:0.8.0'
     testCompile project(':embulk-input-jdbc').sourceSets.test.output
 }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/HstoreColumnGetter.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/HstoreColumnGetter.java
@@ -1,0 +1,63 @@
+package org.embulk.input.postgresql.getter;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.embulk.input.jdbc.getter.AbstractColumnGetter;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonParseException;
+import org.embulk.spi.json.JsonParser;
+import org.embulk.spi.type.Type;
+import org.embulk.spi.type.Types;
+import org.msgpack.value.Value;
+import org.postgresql.util.HStoreConverter;
+
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Map;
+
+public class HstoreColumnGetter
+        extends AbstractColumnGetter
+{
+    final JsonParser parser = new JsonParser();
+    final ObjectMapper mapper = new ObjectMapper();
+
+    private String value;
+
+    public HstoreColumnGetter(PageBuilder to, Type toType)
+    {
+        super(to, toType);
+    }
+
+    @Override
+    protected void fetch(ResultSet from, int fromIndex) throws SQLException
+    {
+        value = from.getString(fromIndex);
+    }
+
+    @Override
+    protected Type getDefaultToType()
+    {
+        return Types.STRING;
+    }
+
+    @Override
+    public void jsonColumn(Column column)
+    {
+        Value v;
+        try {
+            Map map = HStoreConverter.fromString(value);
+            v = parser.parse(mapper.writeValueAsString(map));
+        } catch (JsonProcessingException | JsonParseException e) {
+            super.jsonColumn(column);
+            return;
+        }
+        to.setJson(column, v);
+    }
+
+    @Override
+    public void stringColumn(Column column)
+    {
+        to.setString(column, value);
+    }
+}

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -15,12 +15,12 @@ public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
     }
 
     @Override
-    protected ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
+    public ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option)
     {
         if (column.getTypeName().equals("hstore")) {
             return new HstoreColumnGetter(to, getToType(option));
         } else {
-            return super.newColumnGetter(column, option, valueType);
+            return super.newColumnGetter(column, option);
         }
     }
 

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -2,17 +2,26 @@ package org.embulk.input.postgresql.getter;
 
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
+import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
 import org.joda.time.DateTimeZone;
-
-import java.util.Map;
 
 public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
 {
     public PostgreSQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
     {
         super(to, defaultTimeZone);
+    }
+
+    @Override
+    protected ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option, String valueType)
+    {
+        if (column.getTypeName().equals("hstore")) {
+            return new HstoreColumnGetter(to, getToType(option));
+        } else {
+            return super.newColumnGetter(column, option, valueType);
+        }
     }
 
     @Override

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/EmbulkPluginTester.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/EmbulkPluginTester.java
@@ -1,0 +1,79 @@
+package org.embulk.input.postgresql;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.embulk.EmbulkEmbed;
+import org.embulk.EmbulkEmbed.Bootstrap;
+import org.embulk.config.ConfigSource;
+import org.embulk.plugin.InjectedPluginSource;
+
+import com.google.inject.Binder;
+import com.google.inject.Module;
+
+public class EmbulkPluginTester
+{
+    private static class PluginDefinition
+    {
+        public final Class<?> iface;
+        public final String name;
+        public final Class<?> impl;
+
+
+        public PluginDefinition(Class<?> iface, String name, Class<?> impl)
+        {
+            this.iface = iface;
+            this.name = name;
+            this.impl = impl;
+        }
+
+    }
+
+    private final List<PluginDefinition> plugins = new ArrayList<PluginDefinition>();
+
+    private EmbulkEmbed embulk;
+
+    public EmbulkPluginTester()
+    {
+    }
+
+    public EmbulkPluginTester(Class<?> iface, String name, Class<?> impl)
+    {
+        addPlugin(iface, name, impl);
+    }
+
+    public void addPlugin(Class<?> iface, String name, Class<?> impl)
+    {
+        plugins.add(new PluginDefinition(iface, name, impl));
+    }
+
+    public void run(String ymlPath) throws Exception
+    {
+        if (embulk == null) {
+            Bootstrap bootstrap = new Bootstrap();
+            bootstrap.addModules(new Module()
+            {
+                @Override
+                public void configure(Binder binder)
+                {
+                    for (PluginDefinition plugin : plugins) {
+                        InjectedPluginSource.registerPluginTo(binder, plugin.iface, plugin.name, plugin.impl);
+                    }
+                }
+            });
+            embulk = bootstrap.initializeCloseable();
+        }
+
+        ConfigSource config = embulk.newConfigLoader().fromYamlFile(new File(ymlPath));
+        embulk.run(config);
+    }
+
+    public void destroy() {
+        if (embulk != null) {
+            embulk.destroy();
+            embulk = null;
+        }
+    }
+
+}

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLInputPluginTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLInputPluginTest.java
@@ -1,0 +1,101 @@
+package org.embulk.input.postgresql;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.Charset;
+import java.nio.file.FileSystem;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
+import java.sql.Connection;
+import java.sql.DriverManager;
+import java.sql.Statement;
+import java.util.Arrays;
+import java.util.List;
+
+import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.spi.InputPlugin;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class PostgreSQLInputPluginTest
+{
+    private static final String DATABASE = "test_db";
+    private static final String USER = "test_user";
+    private static final String PASSWORD = "test_pw";
+    private static final String URL = "jdbc:postgresql://localhost:5432/" + DATABASE;
+
+    public static EmbulkPluginTester tester = new EmbulkPluginTester(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class);
+
+    @BeforeClass
+    public static void prepare() throws Exception
+    {
+        // Create User and Database
+        psql(String.format("DROP DATABASE IF EXISTS %s;", DATABASE));
+        psql(String.format("DROP USER IF EXISTS %s;", USER));
+        psql(String.format("CREATE USER %s WITH SUPERUSER PASSWORD '%s';", USER, PASSWORD));
+        psql(String.format("CREATE DATABASE %s WITH OWNER %s;", DATABASE, USER));
+
+        // Insert Data
+        try(Connection connection = DriverManager.getConnection(URL, USER, PASSWORD)) {
+            try (Statement statement = connection.createStatement()) {
+                String sql = "";
+                sql += "DROP TABLE IF EXISTS input_hstore;";
+                sql += "CREATE EXTENSION IF NOT EXISTS hstore WITH SCHEMA public;";
+                sql += "CREATE TABLE input_hstore (c1 hstore);";
+                sql += "INSERT INTO input_hstore (c1) VALUES('\"a\" => \"b\"');";
+                statement.execute(sql);
+            }
+        }
+    }
+
+    @AfterClass
+    public static void dispose()
+    {
+        tester.destroy();
+    }
+
+    @Test
+    public void testHstoreAsString() throws Exception
+    {
+        tester.run(convertPath("/yml/input_hstore.yml"));
+        assertEquals(Arrays.asList("c1", "\"\"\"a\"\"=>\"\"b\"\"\""),
+                read("postgresql-input000.00.csv"));
+    }
+
+    @Test
+    public void testHstoreAsJson() throws Exception
+    {
+        tester.run(convertPath("/yml/input_hstore2.yml"));
+        assertEquals(Arrays.asList("c1", "\"{\"\"a\"\":\"\"b\"\"}\""),
+                read("postgresql-input000.00.csv"));
+    }
+
+    private List<String> read(String path) throws IOException
+    {
+        FileSystem fs = FileSystems.getDefault();
+        return Files.readAllLines(fs.getPath(path), Charset.defaultCharset());
+    }
+
+    private String convertPath(String name) throws URISyntaxException
+    {
+        if (getClass().getResource(name) == null) {
+            return name;
+        }
+        return new File(getClass().getResource(name).toURI()).getAbsolutePath();
+    }
+
+    private static void psql(String sql) throws IOException, InterruptedException {
+        ProcessBuilder pb = new ProcessBuilder("psql", "-c", sql);
+        System.out.println("PSQL: " + pb.command().toString());
+        final Process process = pb.start();
+        final int code = process.waitFor();
+        if (code != 0) {
+            throw new IOException(String.format(
+                    "Command finished with non-zero exit code. Exit code is %d.", code));
+        }
+    }
+}

--- a/embulk-input-postgresql/src/test/resources/yml/input_hstore.yml
+++ b/embulk-input-postgresql/src/test/resources/yml/input_hstore.yml
@@ -1,0 +1,14 @@
+in:
+  type: postgresql
+  host: localhost
+  database: test_db
+  user: test_user
+  password: test_pw
+  table: input_hstore
+  select: "*"
+out:
+  type: file
+  path_prefix: postgresql-input
+  file_ext: csv
+  formatter:
+    type: csv

--- a/embulk-input-postgresql/src/test/resources/yml/input_hstore2.yml
+++ b/embulk-input-postgresql/src/test/resources/yml/input_hstore2.yml
@@ -1,0 +1,16 @@
+in:
+  type: postgresql
+  host: localhost
+  database: test_db
+  user: test_user
+  password: test_pw
+  table: input_hstore
+  select: "*"
+  column_options:
+    c1: {type: json}
+out:
+  type: file
+  path_prefix: postgresql-input
+  file_ext: csv
+  formatter:
+    type: csv


### PR DESCRIPTION
I'd like to deal with PostgreSQL's [hstore](http://www.postgresql.org/docs/9.0/static/hstore.html) column more cleverly in this plugin.
So I tried adding the following specs and implementing those in this PR.
- deal with hstore column as `string` type by default 
  - `"key1"=>"value1", "key2"=>"value2"`
- convert to JSON if specifying the type of hstore column as `json`
  - `"key1"=>"value1", "key2"=>"value2"` => `{"key1": "value1", "key2": "value2"}`

I'd like you to review the specs and implementation, thank you.