### PR TITLE
Allow DESC order at order_by option

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,11 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
-- **default_column_options**: column_options for each JDBC type as default. Key is a JDBC type(e.g. 'DATE', 'BIGINT'). Value is same as column_options's value.
+- **default_column_options**: column_options for each JDBC type as default. Key is a JDBC type (e.g. 'DATE', 'BIGINT'). Value is same as column_options's value.
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`. `value_type: json` is an exception which uses `getString` and parses the result as a JSON string.
   (string, default: depends on the sql type of the column. Available values options are: `long`, `double`, `float`, `decimal`, `boolean`, `string`, `json`, `date`, `time`, `timestamp`)

--- a/README.md
+++ b/README.md
@@ -76,6 +76,16 @@ in:
   table: "my_table"
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM "my_table"
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -192,7 +192,7 @@ public class JdbcInputConnection
         }
 
         if (orderByExpression.isPresent()) {
-            sb.append("ORDER BY ").append(orderByExpression.get());
+            sb.append(" ORDER BY ").append(orderByExpression.get());
         }
 
         return sb.toString();

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -156,8 +156,8 @@ public class JdbcInputConnection
     }
 
     public String buildSelectQuery(String tableName,
-            Optional<String> selectColumnList, Optional<String> whereCondition,
-            Optional<String> orderByColumn) throws SQLException
+            Optional<String> selectExpression, Optional<String> whereCondition,
+            Optional<String> orderByExpression) throws SQLException
     {
         String actualTableName;
         if (tableExists(tableName)) {
@@ -184,38 +184,15 @@ public class JdbcInputConnection
         StringBuilder sb = new StringBuilder();
 
         sb.append("SELECT ");
-        sb.append(selectColumnList.or("*"));
+        sb.append(selectExpression.or("*"));
         sb.append(" FROM ").append(buildTableName(actualTableName));
 
         if (whereCondition.isPresent()) {
             sb.append(" WHERE ").append(whereCondition.get());
         }
 
-        if (orderByColumn.isPresent()) {
-            String actualOrderByColumn;
-            Set<String> columnNames = getColumnNames(actualTableName);
-            if (columnNames.contains(orderByColumn.get())) {
-                actualOrderByColumn = orderByColumn.get();
-            } else {
-                String upperOrderByColumn = orderByColumn.get().toUpperCase();
-                String lowerOrderByColumn = orderByColumn.get().toLowerCase();
-                if (columnNames.contains(upperOrderByColumn)) {
-                    if (columnNames.contains(lowerOrderByColumn)) {
-                        throw new ConfigException(String.format("Cannot specify order-by colum '%s' because both '%s' and '%s' exist.",
-                                orderByColumn.get(), upperOrderByColumn, lowerOrderByColumn));
-                    } else {
-                        actualOrderByColumn = upperOrderByColumn;
-                    }
-                } else {
-                    if (columnNames.contains(lowerOrderByColumn)) {
-                        actualOrderByColumn = lowerOrderByColumn;
-                    } else {
-                        actualOrderByColumn = orderByColumn.get();
-                    }
-                }
-            }
-
-            sb.append("ORDER BY ").append(quoteIdentifierString(actualOrderByColumn)).append(" ASC");
+        if (orderByExpression.isPresent()) {
+            sb.append("ORDER BY ").append(orderByExpression.get());
         }
 
         return sb.toString();

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -58,6 +58,16 @@ in:
   table: my_table
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM `my_table`
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -18,9 +18,9 @@ MySQL input plugins for Embulk loads records from MySQL.
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **fetch_rows**: number of rows to fetch one time (integer, default: 10000)
   - If this value is set to > 1:
     - It uses a server-side prepared statement and fetches rows by chunks.

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -21,9 +21,9 @@ Oracle input plugins for Embulk loads records from Oracle.
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. (integer (seconds), default: 1800)

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -53,6 +53,16 @@ in:
   table: my_table
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM "my_table"
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -68,6 +68,16 @@ in:
   table: my_table
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM "my_table"
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -24,9 +24,9 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -25,9 +25,9 @@ Redshift input plugins for Embulk loads records from Redshift.
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -52,6 +52,16 @@ in:
   table: my_table
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM "my_table"
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -59,6 +59,16 @@ in:
   table: my_table
   select: "col1, col2, col3"
   where: "col4 != 'a'"
+  order_by: "col1 DESC"
+```
+
+This configuration will generate following SQL:
+
+```
+SELECT col1, col2, col3
+FROM "my_table"
+WHERE col4 != 'a'
+ORDER BY col1 DESC
 ```
 
 If you need a complex SQL,

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -26,9 +26,9 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **select**: comma-separated list of columns to select (string, default: "*")
+  - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
-  - **order_by**: name of the column that rows are sorted by (string, default: not sorted)
+  - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
 - **connect_timeout**: timeout for the driver to connect. 0 means the default of SQL Server (15 by default). (integer (seconds), default: 300)
 - **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)


### PR DESCRIPTION
As like other query-part options (`select` and `where`), `order_by` option can assume that the given parameter is an expression. A benefit is that order_by can include multiple columns (e.g. `category, created_at` and/or DESC option `category, created_at DESC`.
