### PR TITLE
Support incremental load

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
 
 Incremental loading uses monotonically increasing unique columns (such as auto-increment id) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
 
 ### Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment id) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as auto-increment id) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -89,13 +89,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ### Example

--- a/README.md
+++ b/README.md
@@ -62,6 +62,41 @@ See [embulk-input-sqlserver](embulk-input-sqlserver/).
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
 
 
+### Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment id) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment primary key.
+
 
 ### Example
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -263,7 +263,6 @@ public abstract class AbstractJdbcInputPlugin
         }
 
         task.setBuiltQuery(builtQuery);
-        logger.info("SQL: " + builtQuery);
 
         // validate column_options
         newColumnGetters(task, querySchema, null);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -413,9 +413,6 @@ public abstract class AbstractJdbcInputPlugin
         long totalRows = 0;
 
         LastRecordStore lastRecordStore = null;
-        if (task.getIncremental()) {
-            lastRecordStore = new LastRecordStore(task.getIncrementalColumnIndexes(), task.getIncrementalColumns());
-        }
 
         try (JdbcInputConnection con = newConnection(task)) {
             List<ColumnGetter> getters = newColumnGetters(task, querySchema, pageBuilder);
@@ -429,7 +426,8 @@ public abstract class AbstractJdbcInputPlugin
                 }
             }
 
-            if (lastRecordStore != null && totalRows > 0) {
+            if (task.getIncremental() && totalRows > 0) {
+                lastRecordStore = new LastRecordStore(task.getIncrementalColumnIndexes(), task.getIncrementalColumns());
                 lastRecordStore.accept(getters);
             }
 
@@ -453,7 +451,7 @@ public abstract class AbstractJdbcInputPlugin
         }
 
         TaskReport report = Exec.newTaskReport();
-        if (lastRecordStore != null && totalRows > 0) {
+        if (lastRecordStore != null) {
             report.set("last_record", lastRecordStore.getList());
         }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -419,7 +419,7 @@ public abstract class AbstractJdbcInputPlugin
 
         try (JdbcInputConnection con = newConnection(task)) {
             List<ColumnGetter> getters = newColumnGetters(task, querySchema, pageBuilder);
-            try (BatchSelect cursor = con.newSelectCursor(builtQuery.getQuery(), builtQuery.getParameters(), getters, task.getFetchRows(), task.getSocketTimeout())) {
+            try (BatchSelect cursor = con.newSelectCursor(builtQuery, getters, task.getFetchRows(), task.getSocketTimeout())) {
                 while (true) {
                     long rows = fetch(cursor, getters, pageBuilder);
                     if (rows <= 0L) {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumn.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumn.java
@@ -44,7 +44,6 @@ public class JdbcColumn
         return sqlType;
     }
 
-
     @JsonProperty("precision")
     public int getPrecision()
     {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -18,6 +18,8 @@ import java.util.List;
 import java.util.ArrayList;
 import static java.util.Locale.ENGLISH;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
@@ -221,17 +223,22 @@ public class JdbcInputConnection
         private final String query;
         private final List<JdbcLiteral> parameters;
 
-        public PreparedQuery(String query, List<JdbcLiteral> parameters)
+        @JsonCreator
+        public PreparedQuery(
+                @JsonProperty("query") String query,
+                @JsonProperty("parameters") List<JdbcLiteral> parameters)
         {
             this.query = query;
             this.parameters = parameters;
         }
 
+        @JsonProperty("query")
         public String getQuery()
         {
             return query;
         }
 
+        @JsonProperty("parameters")
         public List<JdbcLiteral> getParameters()
         {
             return parameters;

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcLiteral.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcLiteral.java
@@ -1,0 +1,38 @@
+package org.embulk.input.jdbc;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.JsonNode;
+
+public class JdbcLiteral
+{
+    private final int columnIndex;
+    private final JsonNode value;
+
+    @JsonCreator
+    public JdbcLiteral(
+            @JsonProperty("columnIndex") int columnIndex,
+            @JsonProperty("value") JsonNode value)
+    {
+        this.columnIndex = columnIndex;
+        this.value = value;
+    }
+
+    @JsonProperty("columnIndex")
+    public int getColumnIndex()
+    {
+        return columnIndex;
+    }
+
+    @JsonProperty("value")
+    public JsonNode getValue()
+    {
+        return value;
+    }
+
+    @Override
+    public String toString()
+    {
+        return value.toString();
+    }
+}

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcSchema.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcSchema.java
@@ -1,6 +1,7 @@
 package org.embulk.input.jdbc;
 
 import java.util.List;
+import com.google.common.base.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -33,5 +34,22 @@ public class JdbcSchema
     public String getColumnName(int i)
     {
         return columns.get(i).getName();
+    }
+
+    public Optional<Integer> findColumn(String caseInsensitiveName)
+    {
+        // find by case sensitive first
+        for (int i = 0; i < columns.size(); i++) {
+            if (getColumn(i).getName().equals(caseInsensitiveName)) {
+                return Optional.of(i);
+            }
+        }
+        // find by case insensitive
+        for (int i = 0; i < columns.size(); i++) {
+            if (getColumn(i).getName().equalsIgnoreCase(caseInsensitiveName)) {
+                return Optional.of(i);
+            }
+        }
+        return Optional.absent();
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
@@ -1,14 +1,21 @@
 package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import org.embulk.spi.Column;
 import org.embulk.spi.ColumnVisitor;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Type;
+import org.embulk.spi.DataException;
+import static java.util.Locale.ENGLISH;
 
 public abstract class AbstractColumnGetter implements ColumnGetter, ColumnVisitor
 {
+    protected static final JsonNodeFactory jsonNodeFactory = JsonNodeFactory.instance;
+
     protected final PageBuilder to;
     private final Type toType;
 
@@ -20,8 +27,8 @@ public abstract class AbstractColumnGetter implements ColumnGetter, ColumnVisito
 
     @Override
     public void getAndSet(ResultSet from, int fromIndex,
-            Column toColumn) throws SQLException {
-
+            Column toColumn) throws SQLException
+    {
         fetch(from, fromIndex);
         if (from.wasNull()) {
             to.setNull(toColumn);
@@ -79,4 +86,20 @@ public abstract class AbstractColumnGetter implements ColumnGetter, ColumnVisito
 
     protected abstract Type getDefaultToType();
 
+    @Override
+    public JsonNode encodeToJson()
+    {
+        throw new DataException(String.format(ENGLISH,
+                            "Column type '%s' set at incremental_columns option is not supported",
+                            getToType()));
+    }
+
+    @Override
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+        throws SQLException
+    {
+        throw new DataException(String.format(ENGLISH,
+                            "Converting last_record value %s to column index %d is not supported",
+                            fromValue.toString(), toIndex));
+    }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetter.java
@@ -2,6 +2,8 @@ package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.sql.PreparedStatement;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.spi.Column;
 import org.embulk.spi.type.Type;
 
@@ -11,4 +13,9 @@ public interface ColumnGetter
             Column toColumn) throws SQLException;
 
     public Type getToType();
+
+    public JsonNode encodeToJson();
+
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+        throws SQLException;
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/LongColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/LongColumnGetter.java
@@ -1,7 +1,9 @@
 package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Type;
@@ -53,4 +55,16 @@ public class LongColumnGetter
         to.setString(column, Long.toString(value));
     }
 
+    @Override
+    public JsonNode encodeToJson()
+    {
+        return jsonNodeFactory.numberNode(value);
+    }
+
+    @Override
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+        throws SQLException
+    {
+        toStatement.setLong(toIndex, fromValue.asLong());
+    }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
@@ -1,7 +1,9 @@
 package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
+import java.sql.PreparedStatement;
 import java.sql.SQLException;
+import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.json.JsonParseException;
@@ -79,4 +81,16 @@ public class StringColumnGetter
         to.setString(column, value);
     }
 
+    @Override
+    public JsonNode encodeToJson()
+    {
+        return jsonNodeFactory.textNode(value);
+    }
+
+    @Override
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+        throws SQLException
+    {
+        toStatement.setString(toIndex, fromValue.asText());
+    }
 }

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -54,7 +54,7 @@ MySQL input plugins for Embulk loads records from MySQL.
 
 Incremental loading uses monotonically increasing unique columns (such as AUTO_INCREMENT column) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -52,9 +52,9 @@ MySQL input plugins for Embulk loads records from MySQL.
 
 ## Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as AUTO_INCREMENT column) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as AUTO_INCREMENT column) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -77,13 +77,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -34,6 +34,9 @@ MySQL input plugins for Embulk loads records from MySQL.
 - **connect_timeout**: timeout for socket connect. 0 means no timeout. (integer (seconds), default: 300)
 - **socket_timeout**: timeout on network socket operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys)
+- **last_record**: values of the last record for incremental loading (array of objects, default: load all records)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
@@ -45,6 +48,43 @@ MySQL input plugins for Embulk loads records from MySQL.
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
+
+
+## Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as AUTO_INCREMENT column) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key.
+
 
 ## Example
 

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -19,15 +19,18 @@ public class MySQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(String select,
-            List<JdbcLiteral> parameters, List<ColumnGetter> getters,
+    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery,
+            List<ColumnGetter> getters,
             int fetchRows, int queryTimeout) throws SQLException
     {
-        logger.info("SQL: " + select);
-        PreparedStatement stmt = connection.prepareStatement(select, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
-        if (!parameters.isEmpty()) {
-            logger.info("Parameters: {}", parameters);
-            prepareParameters(stmt, getters, parameters);
+        String query = preparedQuery.getQuery();
+        List<JdbcLiteral> params = preparedQuery.getParameters();
+
+        logger.info("SQL: " + query);
+        PreparedStatement stmt = connection.prepareStatement(query, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
+        if (!params.isEmpty()) {
+            logger.info("Parameters: {}", params);
+            prepareParameters(stmt, getters, params);
         }
         if (fetchRows == 1) {
             // See MySQLInputPlugin.newConnection doesn't set useCursorFetch=true when fetchRows=1

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -26,7 +26,7 @@ public class MySQLInputConnection
         }
         PreparedStatement stmt = connection.prepareStatement(select, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
         for (int i = 0; i < placeHolderValues.size(); i++) {
-            stmt.setString(i + 1, placeHolderValues.get(i));
+            stmt.setString(i + 1, placeHolderValues.get(i).toString());
         }
         if (fetchRows == 1) {
             // See MySQLInputPlugin.newConnection doesn't set useCursorFetch=true when fetchRows=1

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -1,5 +1,6 @@
 package org.embulk.input.mysql;
 
+import java.util.List;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -16,10 +17,17 @@ public class MySQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(String select, int fetchRows, int queryTimeout) throws SQLException
+    protected BatchSelect newBatchSelect(String select, List<Number> placeHolderValues,
+            int fetchRows, int queryTimeout) throws SQLException
     {
         logger.info("SQL: " + select);
+        if (!placeHolderValues.isEmpty()) {
+            logger.info("Parameters: {}", placeHolderValues);
+        }
         PreparedStatement stmt = connection.prepareStatement(select, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
+        for (int i = 0; i < placeHolderValues.size(); i++) {
+            stmt.setString(i + 1, placeHolderValues.get(i));
+        }
         if (fetchRows == 1) {
             // See MySQLInputPlugin.newConnection doesn't set useCursorFetch=true when fetchRows=1
             // MySQL Connector/J keeps the connection opened and process rows one by one with Integer.MIN_VALUE.

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -26,7 +26,7 @@ public class MySQLInputConnection
         }
         PreparedStatement stmt = connection.prepareStatement(select, ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);  // TYPE_FORWARD_ONLY and CONCUR_READ_ONLY are default
         for (int i = 0; i < placeHolderValues.size(); i++) {
-            stmt.setString(i + 1, placeHolderValues.get(i).toString());
+            stmt.setObject(i + 1, placeHolderValues.get(i));
         }
         if (fetchRows == 1) {
             // See MySQLInputPlugin.newConnection doesn't set useCursorFetch=true when fetchRows=1

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -48,7 +48,7 @@ Oracle input plugins for Embulk loads records from Oracle.
 
 Incremental loading uses monotonically increasing unique columns (such as incremental (SEQUENCE) column) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -28,6 +28,9 @@ Oracle input plugins for Embulk loads records from Oracle.
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys)
+- **last_record**: values of the last record for incremental loading (array of objects, default: load all records)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
@@ -39,6 +42,43 @@ Oracle input plugins for Embulk loads records from Oracle.
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
+
+
+### Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as incremental (SEQUENCE) column) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key.
+
 
 ## Example
 

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -46,9 +46,9 @@ Oracle input plugins for Embulk loads records from Oracle.
 
 ### Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as incremental (SEQUENCE) column) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as incremental (SEQUENCE) column) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -71,13 +71,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -63,7 +63,7 @@ In addition, `json` type is supported for `hstore` column, and output will be as
 
 Incremental loading uses monotonically increasing unique columns (such as auto-increment (serial / bigserial) column) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -61,9 +61,9 @@ In addition, `json` type is supported for `hstore` column, and output will be as
 
 ### Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment (serial / bigserial) column) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as auto-increment (serial / bigserial) column) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -86,13 +86,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -27,6 +27,9 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
   - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
   - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys)
+- **last_record**: values of the last record for incremental loading (array of objects, default: load all records)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
@@ -54,6 +57,42 @@ In addition, `json` type is supported for `hstore` column, and output will be as
 ```
 
 `value_type` is ignored.
+
+
+### Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment (serial / bigserial) column) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key.
 
 
 ## Example

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
@@ -23,18 +23,19 @@ public class PostgreSQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(String select,
-            List<JdbcLiteral> parameters, List<ColumnGetter> getters,
+    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery,
+            List<ColumnGetter> getters,
             int fetchRows, int queryTimeout) throws SQLException
     {
-        String sql = "DECLARE cur NO SCROLL CURSOR FOR " + select;
+        String query = "DECLARE cur NO SCROLL CURSOR FOR " + preparedQuery.getQuery();
+        List<JdbcLiteral> params = preparedQuery.getParameters();
 
-        logger.info("SQL: " + sql);
-        PreparedStatement stmt = connection.prepareStatement(sql);
+        logger.info("SQL: " + query);
+        PreparedStatement stmt = connection.prepareStatement(query);
         try {
-            if (!parameters.isEmpty()) {
-                logger.info("Parameters: {}", parameters);
-                prepareParameters(stmt, getters, parameters);
+            if (!params.isEmpty()) {
+                logger.info("Parameters: {}", params);
+                prepareParameters(stmt, getters, params);
             }
             stmt.executeUpdate();
         } finally {

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -48,7 +48,7 @@ Redshift input plugins for Embulk loads records from Redshift.
 
 Incremental loading uses monotonically increasing unique columns (such as auto-increment (IDENTITY) column) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -28,6 +28,9 @@ Redshift input plugins for Embulk loads records from Redshift.
   - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
   - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys)
+- **last_record**: values of the last record for incremental loading (array of objects, default: load all records)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
@@ -39,6 +42,43 @@ Redshift input plugins for Embulk loads records from Redshift.
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
+
+
+### Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment (IDENTITY) column) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key.
+
 
 ## Example
 

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -46,9 +46,9 @@ Redshift input plugins for Embulk loads records from Redshift.
 
 ### Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as auto-increment (IDENTITY) column) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as auto-increment (IDENTITY) column) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -71,13 +71,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -33,6 +33,9 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
 - **connect_timeout**: timeout for the driver to connect. 0 means the default of SQL Server (15 by default). (integer (seconds), default: 300)
 - **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)
 - **options**: extra JDBC properties (hash, default: {})
+- **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
+- **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys)
+- **last_record**: values of the last record for incremental loading (array of objects, default: load all records)
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
@@ -44,6 +47,43 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
+
+
+### Incremental loading
+
+If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as IDENTITY column) to load records inserted (or updated) after last execution.
+
+If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+ORDER BY updated_at, id
+```
+
+When bulk data loading finishes successfully, it outputs `last_record: ` paramater as config-diff so that next execution uses it.
+
+At the next execution, when `last_record: ` is also set, this plugin generates additional WHERE conditions to load records larger than the last record. For example, if `last_record: ["2017-01-01 00:32:12", 5291]` is set,
+
+```
+SELECT * FROM (
+  ...original query is here...
+)
+WHERE created_at > '2017-01-01 00:32:12' OR (created_at = '2017-01-01 00:32:12' AND id > 5291)
+ORDER BY updated_at, id
+```
+
+Then, it updates `last_record: ` so that next execution uses the updated last_record.
+
+**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+
+```
+CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
+```
+
+Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key.
+
 
 ## Example
 

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -53,7 +53,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
 
 Incremental loading uses monotonically increasing unique columns (such as IDENTITY column) to load records inserted (or updated) after last execution.
 
-First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `incremental: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -51,9 +51,9 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
 
 ### Incremental loading
 
-If `incremental: true` option is set, incremental loading is enabled. Incremental loading generates additional WHERE conditions on one multiple incrementing columns (such as IDENTITY column) to load records inserted (or updated) after last execution.
+Incremental loading uses monotonically increasing unique columns (such as IDENTITY column) to load records inserted (or updated) after last execution.
 
-If `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
+First, if `increment: true` is set, this plugin loads all records with additional ORDER BY. For example, if `incremental_columns: [updated_at, id]` option is set, query will be as following:
 
 ```
 SELECT * FROM (
@@ -76,13 +76,13 @@ ORDER BY updated_at, id
 
 Then, it updates `last_record: ` so that next execution uses the updated last_record.
 
-**IMPORTANT**: Make sure that there is an index on incremental_columns. If the columns are not indexed, it runs full table scan. For this example, following index should be created:
+**IMPORTANT**: If you set `incremental_columns: ` option, make sure that there is an index on the columns to avoid full table scan. For this example, following index should be created:
 
 ```
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Currently, only strings and integers are supported as incremental_columns. Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key. Currently, only strings and integers are supported as incremental_columns.
 
 
 ## Example


### PR DESCRIPTION
Design review of #55.
This assumes that #56 is merged.

This code supports only integers as strings as last_record option. It needs to be strict typing to support postgresql which doesn't have much implicit type conversion. Implementation would use ColumnGetter mechanism for type conversion from ResultSet to `Map<String, Object> lastRecord`, and from `Map<String, Object> lastRecord` to `PreparedStatement.setXxx(index, thisValue)`

