### PR TITLE
Suggest column_options for unsupported types

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -14,6 +14,8 @@ import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
 
+import static java.util.Locale.ENGLISH;
+
 public class ColumnGetterFactory
 {
     protected final PageBuilder to;
@@ -58,7 +60,8 @@ public class ColumnGetterFactory
         case "decimal":
             return new BigDecimalColumnGetter(to, toType);
         default:
-            throw new ConfigException(String.format("Unknown value_type '%s' for column '%s'", option.getValueType(), column.getName()));
+            throw new ConfigException(String.format(ENGLISH,
+                        "Unknown value_type '%s' for column '%s'", option.getValueType(), column.getName()));
         }
     }
 
@@ -185,7 +188,8 @@ public class ColumnGetterFactory
     private static UnsupportedOperationException unsupportedOperationException(JdbcColumn column)
     {
         throw new UnsupportedOperationException(
-                String.format("Unsupported type %s (sqlType=%d) of '%s' column. Please exclude the column from 'select:' option.",
-                    column.getTypeName(), column.getSqlType(), column.getName()));
+                String.format(ENGLISH,
+                    "Unsupported type %s (sqlType=%d) of '%s' column. Please add '%s: {type: string}' to 'column_options: {...}' option to convert the values to strings, or exclude the column from 'select:' option",
+                    column.getTypeName(), column.getSqlType(), column.getName(), column.getName()));
     }
 }


### PR DESCRIPTION
When "Unsupported type..." error happens, embulk still can convert them into other types.
Typical use case is converting them to strings.

This error happened when we tried to load `uuid` column from a PostgreSQL server.

```
  java.lang.UnsupportedOperationException: Unsupported type uuid (sqlType=1111) of 'session_uuid' column. Please exclude the column from 'select:' option.
  	at org.embulk.input.jdbc.getter.ColumnGetterFactory.unsupportedOperationException(ColumnGetterFactory.java:187)
  	at org.embulk.input.jdbc.getter.ColumnGetterFactory.sqlTypeToValueType(ColumnGetterFactory.java:161)
  	at org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory.sqlTypeToValueType(PostgreSQLColumnGetterFactory.java:33)
  	at org.embulk.input.jdbc.getter.ColumnGetterFactory.newColumnGetter(ColumnGetterFactory.java:39)
  	at org.embulk.input.jdbc.getter.ColumnGetterFactory.newColumnGetter(ColumnGetterFactory.java:31)
  	at org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory.newColumnGetter(PostgreSQLColumnGetterFactory.java:23)
  	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.newColumnGetters(AbstractJdbcInputPlugin.java:301)
  	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.setupTask(AbstractJdbcInputPlugin.java:175)
  	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(AbstractJdbcInputPlugin.java:158)
```

