### PR TITLE
postgresql: support application_name option

### DIFF
--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -19,6 +19,7 @@ PostgreSQL input plugins for Embulk loads records from PostgreSQL.
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **ssl**: enables SSL. data will be encrypted but CA or certification will not be verified (boolean, default: false)
+- **application_name**: application name shown on pg_stat_activity. (string, default: "embulk-input-postgresql")
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,
   - **query**: SQL to run (string)

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -48,6 +48,10 @@ public class PostgreSQLInputPlugin
         @Config("ssl")
         @ConfigDefault("false")
         public boolean getSsl();
+
+        @Config("application_name")
+        @ConfigDefault("\"embulk-input-postgresql\"")
+        public String getApplicationName();
     }
 
     @Override
@@ -81,6 +85,8 @@ public class PostgreSQLInputPlugin
             props.setProperty("sslfactory", "org.postgresql.ssl.NonValidatingFactory");  // disable server-side validation
         }
         // setting ssl=false enables SSL. See org.postgresql.core.v3.openConnectionImpl.
+
+        props.setProperty("ApplicationName", t.getApplicationName());
 
         props.putAll(t.getOptions());
 


### PR DESCRIPTION
This is useful for system administrators to know that a long-running query is issued using embulk-input-postgresql plugin.