### PR TITLE
[WIP] Support Date/Time types column for incremental_columns

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
@@ -1,8 +1,11 @@
 package org.embulk.input.jdbc.getter;
 
 import java.sql.Date;
+import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+
+import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.time.TimestampFormatter;
@@ -13,10 +16,12 @@ public class DateColumnGetter
         extends AbstractTimestampColumnGetter
 {
     static final String DEFAULT_FORMAT = "%Y-%m-%d";
+    private final TimestampFormatter formatter;
 
     public DateColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter)
     {
         super(to, toType, timestampFormatter);
+        this.formatter = timestampFormatter;
     }
 
     @Override
@@ -34,4 +39,16 @@ public class DateColumnGetter
         return Types.TIMESTAMP.withFormat(DEFAULT_FORMAT);
     }
 
+    @Override
+    public JsonNode encodeToJson()
+    {
+        return jsonNodeFactory.textNode(formatter.format(value));
+    }
+
+    @Override
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+            throws SQLException
+    {
+        toStatement.setDate(toIndex, Date.valueOf(fromValue.asText()));
+    }
 }

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -83,7 +83,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key. Currently, only strings, integers and date/time are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -77,7 +77,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key. Currently, only strings, integers and date/time are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -93,7 +93,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key. Currently, only strings, integers and date/time are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -77,7 +77,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key. Currently, only strings, integers and date/time  are supported as incremental_columns.
 
 
 ## Example

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -83,7 +83,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key. Currently, only strings, integers and date/time are supported as incremental_columns.
 
 
 ## Example


### PR DESCRIPTION
Currently, embulk-input-jdbc/\* supports **string** and **integers** for `incremental_columns`.
I added Date,DateTime,Timestamp,Time supports.
### Example

``` yaml
in:
  type: postgresql
  ...
  incremental: true
  incremental_columns: [ts_column]
  last_record: ["2016-11-05 08:12:34"]
  column_options:
    ts_column: {type: string, timestamp_format: "%Y-%m-%d %H:%M:%S", timezone: "+0900"}
```

``` sh
$ embulk run postgresql.yml
SELECT * FROM "incremental" WHERE (("ts_column" > ?)) ORDER BY "ts_column"
Parameters: ["2016-11-05 08:12:34"]
...
Committed.
Next config diff: {"in":{"last_record":["2017-02-23 19:51:11"]},"out":{}}
```
