### PR TITLE
[WIP] Support timestamp/timestamptz type for PostgreSQL incremental_columns

### DIFF
--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -5,22 +5,35 @@ import org.embulk.input.jdbc.JdbcColumnOption;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.spi.time.TimestampFormatter;
 import org.joda.time.DateTimeZone;
 
 public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
 {
+    private final DateTimeZone defaultTimeZone;
+    private static final String TIMESTAMP_DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S.%6N";
+    private static final String TIMESTAMPTZ_DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S.%6N %Z";
+
     public PostgreSQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
     {
         super(to, defaultTimeZone);
+        this.defaultTimeZone = defaultTimeZone;
     }
 
     @Override
     public ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option)
     {
-        if (column.getTypeName().equals("hstore")) {
-            return new HstoreColumnGetter(to, getToType(option));
-        } else {
-            return super.newColumnGetter(column, option);
+        String columnTypeName = column.getTypeName().toLowerCase();
+        DateTimeZone timezone = option.getTimeZone().or(defaultTimeZone);
+        switch(columnTypeName) {
+            case "hstore":
+                return new HstoreColumnGetter(to, getToType(option));
+            case "timestamp":
+                return new TimestampColumnGetter(to, getToType(option), columnTypeName, newTimestampFormatter(option, TIMESTAMP_DEFAULT_FORMAT), timezone);
+            case "timestamptz":
+                return new TimestampColumnGetter(to, getToType(option), columnTypeName, newTimestampFormatter(option, TIMESTAMPTZ_DEFAULT_FORMAT), timezone);
+            default:
+                return super.newColumnGetter(column, option);
         }
     }
 
@@ -32,5 +45,13 @@ public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
         } else {
             return super.sqlTypeToValueType(column, sqlType);
         }
+    }
+
+    private TimestampFormatter newTimestampFormatter(JdbcColumnOption option, String defaultTimestampFormat)
+    {
+        return new TimestampFormatter(
+                option.getJRuby(),
+                option.getTimestampFormat().isPresent() ? option.getTimestampFormat().get().getFormat() : defaultTimestampFormat,
+                option.getTimeZone().or(defaultTimeZone));
     }
 }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/TimestampColumnGetter.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/TimestampColumnGetter.java
@@ -1,0 +1,78 @@
+package org.embulk.input.postgresql.getter;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import org.embulk.config.ConfigException;
+import org.embulk.input.jdbc.getter.AbstractTimestampColumnGetter;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.time.Timestamp;
+import org.embulk.spi.time.TimestampFormatter;
+import org.embulk.spi.type.Type;
+import org.embulk.spi.type.Types;
+import org.joda.time.DateTimeZone;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+
+public class TimestampColumnGetter
+        extends AbstractTimestampColumnGetter
+{
+    private static final String DEFAULT_FORMAT = "%Y-%m-%d %H:%M:%S";
+    private final TimestampFormatter formatter;
+    private final String columnTypeName;
+    private final DateTimeZone timezone;
+
+    public TimestampColumnGetter(PageBuilder to, Type toType, String columnTypeName, TimestampFormatter timestampFormatter, DateTimeZone timezone)
+    {
+        super(to, toType, timestampFormatter);
+        this.formatter = timestampFormatter;
+        this.columnTypeName = columnTypeName;
+        this.timezone = timezone;
+    }
+
+    @Override
+    protected void fetch(ResultSet from, int fromIndex) throws SQLException
+    {
+        java.sql.Timestamp timestamp = from.getTimestamp(fromIndex);
+        if (timestamp != null) {
+            value = Timestamp.ofEpochSecond(timestamp.getTime() / 1000, timestamp.getNanos());
+        }
+    }
+
+    @Override
+    protected Type getDefaultToType()
+    {
+        return Types.TIMESTAMP.withFormat(DEFAULT_FORMAT);
+    }
+
+    @Override
+    public JsonNode encodeToJson()
+    {
+        return jsonNodeFactory.textNode(formatter.format(value));
+    }
+
+    @Override
+    public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
+            throws SQLException
+    {
+        switch (columnTypeName) {
+            case "timestamp":
+                toStatement.setTimestamp(toIndex, java.sql.Timestamp.valueOf(fromValue.asText()));
+                break;
+            case "timestamptz":
+                SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss.SSSSSS z");
+                dateFormatter.setTimeZone(timezone.toTimeZone());
+                try {
+                    java.sql.Timestamp t = new java.sql.Timestamp(dateFormatter.parse(fromValue.asText()).getTime());
+                    toStatement.setTimestamp(toIndex, t);
+                } catch (ParseException e) {
+                    throw new ConfigException(e);
+                }
+                break;
+            default:
+                toStatement.setTimestamp(toIndex, java.sql.Timestamp.valueOf(fromValue.asText()));
+        }
+    }
+}


### PR DESCRIPTION
Revise of #73.

This pull-requests focused to PostgreSQL. Additionally supported `timestamp` and `timestamptz`(timestamp with timezone) type columns as incremental_columns.

Plugin will raise exception when...
* Column type is timestamp and DB type is not PostgreSQL
* Column type is time, timetz, or any types that don't include year/month/date
* Column type is date, or any types that don't include hour/minute/seconds