### PR TITLE
[WIP] Adding support for incremental loading using datetime and timestamp types to MySQL

### DIFF
--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -150,3 +150,17 @@ in:
 ```
 $ ./gradlew gem
 ```
+
+Running tests:
+
+NOTE: Run your MySQL instance with `Europe/Helsinki` timezone.
+
+```
+$ cp ci/travis_mysql.yml ci/mysql.yml  # edit this file if necessary
+$ EMBULK_INPUT_MYSQL_TEST_CONFIG=`pwd`/ci/mysql.yml ./gradlew :embulk-input-mysql:check --info
+```
+
+* If you executes test from GUI enviroment(IDE), be sure to set following JVM options
+```
+-Duser.timezone=Europe/Helsinki
+```

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -7,7 +7,11 @@ import java.sql.SQLException;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
+import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.mysql.MySQLInputConnection;
+import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
 
 public class MySQLInputPlugin
         extends AbstractJdbcInputPlugin
@@ -108,5 +112,11 @@ public class MySQLInputPlugin
                 con.close();
             }
         }
+    }
+
+    @Override
+    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    {
+        return new MySQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -1,0 +1,34 @@
+package org.embulk.input.mysql.getter;
+
+import org.embulk.input.jdbc.JdbcColumn;
+import org.embulk.input.jdbc.JdbcColumnOption;
+import org.embulk.input.jdbc.getter.ColumnGetter;
+import org.embulk.input.jdbc.getter.ColumnGetterFactory;
+import org.embulk.input.jdbc.getter.TimestampWithTimeZoneIncrementalHandler;
+import org.embulk.input.jdbc.getter.TimestampWithoutTimeZoneIncrementalHandler;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
+
+public class MySQLColumnGetterFactory extends ColumnGetterFactory
+{
+    public MySQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    {
+        super(to, defaultTimeZone);
+    }
+
+    @Override
+    public ColumnGetter newColumnGetter(JdbcColumn column, JdbcColumnOption option)
+    {
+        ColumnGetter getter = super.newColumnGetter(column, option);
+
+        // incremental loading wrapper
+        switch (column.getTypeName()) {
+        case "DATETIME":
+            return new TimestampWithoutTimeZoneIncrementalHandler(getter);
+        case "TIMESTAMP":
+            return new TimestampWithTimeZoneIncrementalHandler(getter);
+        default:
+            return getter;
+        }
+    }
+}


### PR DESCRIPTION
Similar with PostgreSQL timestamp/timestamptz incremental load supports #79.

This implementation supports `TIMESTAMP` and `DATETIME` type columns of MySQL.

I don't rewrite existing test case with new EmbulkTest framework for now.
Current test case of embulk-input-mysql is using CSV formatter and EmbulkTest only accepts inputConfig, doen't accept outputConfig.
https://github.com/embulk/embulk/blob/master/embulk-test/src/main/java/org/embulk/test/TestingEmbulk.java#L170