### PR TITLE
Apply test jvmArgs and environment to postgresql project only

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,10 +102,15 @@ subprojects {
         }
     }
 
-    test {
-        // JDBC input plugins depend on local time zone to parse timestamp without time stamp and datetime types.
-        jvmArgs "-Duser.country=FI -Duser.timezone=Europe/Helsinki"
-        environment "TZ", "Europe/Helsinki"
+    // TODO:
+    // The unit tests fail causes the test setting except postgresql project. It's better to apply
+    // the settings to all projects.
+    if (it.name.endsWith('-postgresql')) {
+        test {
+            // JDBC input plugins depend on local time zone to parse timestamp without time stamp and datetime types.
+            jvmArgs "-Duser.country=FI -Duser.timezone=Europe/Helsinki"
+            environment "TZ", "Europe/Helsinki"
+        }
     }
 
     task classpath(type: Copy, dependsOn: ["jar"]) {


### PR DESCRIPTION
I noticed that the commit https://github.com/embulk/embulk-input-jdbc/commit/b37ea5c361477ec7d86658192e4c2ec69b9e4dac broke unit tests for each projects except postgresql's. This settings is good for unit tests running on Travis-CI. But, now it's better to apply postgresql test only.