### PR TITLE
mysql: Fix false validation error for mysql incremental loading

### DIFF
--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.input.mysql.getter;
 
+import com.google.common.base.Optional;
 import org.embulk.config.ConfigException;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin.PluginTask;
 import org.embulk.input.jdbc.JdbcColumn;
@@ -31,7 +32,8 @@ public class MySQLColumnGetterFactory
         switch (column.getTypeName()) {
         case "DATETIME":
         case "TIMESTAMP":
-            if (!task.getIncremental()) {
+            int index = task.getQuerySchema().findColumn(column.getName()).get();
+            if (!task.getIncremental() || !task.getIncrementalColumnIndexes().contains(index)) {
                 return getter;
             }
 


### PR DESCRIPTION
This will fix a false validation error (ConfigException) bug, which was produced on https://github.com/embulk/embulk-input-jdbc/pull/89. The mysql plugin throws ConfigException like following if the query schema has datetime or timestamp typed columns and `incremental` option is `true`. If users want to use int columns for incremental columns, the validation error happens. 

```
Caused by: org.embulk.config.ConfigException: Must use 'useLegacyDatetimeCode=false' if 'DATETIME' or 'TIMESTAMP' typed columns are used as incremental_columns:
	at org.embulk.input.mysql.getter.MySQLColumnGetterFactory.newColumnGetter(MySQLColumnGetterFactory.java:48)
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.newColumnGetters(AbstractJdbcInputPlugin.java:484)
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.setupTask(AbstractJdbcInputPlugin.java:264)
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(AbstractJdbcInputPlugin.java:188)
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:528)
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389)
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385)
	at org.embulk.spi.Exec.doWith(Exec.java:25)
	at org.embulk.exec.BulkLoader.run(BulkLoader.java:385)
	at org.embulk.EmbulkEmbed.run(EmbulkEmbed.java:180)
... ...
```

