### PR TITLE
Feature/add support for oracle tnsname ora file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ build/
 .idea
 /out/
 ci/postgresql.yml
+
+embulk-input-oracle/driver/

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -17,6 +17,8 @@ Oracle input plugin for Embulk loads records from Oracle.
 - **database**: destination database name (string, required if url is not set)
 - **schema**: destination schema name (string, default: use the default schema). old Oracle JDBC driver (ojdbc6.jar) doesn't support.
 - **url**: URL of the JDBC connection (string, optional)
+- **tns_admin_path**: Directory which contains tnsname.ora (string, optional, must be present if **net_service_name** is defined)
+- **net_service_name**: Oracle Net Service Name (string, optional)
 - If you write SQL directly,
   - **query**: SQL to run (string)
 - If **query** is not set,

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -76,16 +76,20 @@ public class OracleInputPlugin
                 throw new IllegalArgumentException("'host', 'port' and 'database' parameters are invalid if 'url' parameter is set.");
             }
             if (oracleTask.getNetServiceName().isPresent() || oracleTask.getTnsAdminPath().isPresent()) {
-                throw new IllegalArgumentException("'tnsname', 'tnsname_path' parameters are invalid if 'url' parameter is set.");
+                throw new IllegalArgumentException("'net_service_name', 'tns_admin_path' parameters are invalid if 'url' parameter is set.");
             }
             url = oracleTask.getUrl().get();
-        } else if (oracleTask.getNetServiceName().isPresent() && oracleTask.getTnsAdminPath().isPresent()) {
+        } else if (oracleTask.getNetServiceName().isPresent()) {
+            if (!oracleTask.getTnsAdminPath().isPresent()) {
+                throw new IllegalArgumentException("'tns_admin_path' parameter is required if 'net_service_name' parameter is set.");
+            }
             if (oracleTask.getHost().isPresent() || oracleTask.getDatabase().isPresent()) {
-                throw new IllegalArgumentException("'host' and 'database' parameters are invalid if 'tnsname' and 'tnsname_path' parameters are set.");
+                throw new IllegalArgumentException("'host' and 'database' parameters are invalid if 'net_service_name' and 'tns_admin_path' parameters are set.");
             }
             System.setProperty("oracle.net.tns_admin", oracleTask.getTnsAdminPath().get());
-            logger.debug(String.format("Setting up env variable oracle.net.tns_admin to be %s", oracleTask.getTnsAdminPath().get()));
             url = String.format("jdbc:oracle:thin:@%s", oracleTask.getNetServiceName().get());
+        } else if (oracleTask.getTnsAdminPath().isPresent() && !oracleTask.getNetServiceName().isPresent()) {
+            throw new IllegalArgumentException("'net_service_name' parameter is required if 'tns_admin_path' parameter is set.");
         } else {
             if (!oracleTask.getHost().isPresent()) {
                 throw new IllegalArgumentException("Field 'host' is not set.");

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -50,13 +50,13 @@ public class OracleInputPlugin
         @ConfigDefault("\"\"")
         public String getPassword();
 
-        @Config("tnsname_path")
+        @Config("tns_admin_path")
         @ConfigDefault("null")
-        public Optional<String> getTnsnamePath();
+        public Optional<String> getTnsAdminPath();
 
-        @Config("tnsname")
+        @Config("net_service_name")
         @ConfigDefault("null")
-        public Optional<String> getTnsname();
+        public Optional<String> getNetServiceName();
     }
 
     @Override
@@ -75,20 +75,17 @@ public class OracleInputPlugin
             if (oracleTask.getHost().isPresent() || oracleTask.getDatabase().isPresent()) {
                 throw new IllegalArgumentException("'host', 'port' and 'database' parameters are invalid if 'url' parameter is set.");
             }
-            if (oracleTask.getTnsname().isPresent() || oracleTask.getTnsnamePath().isPresent()) {
+            if (oracleTask.getNetServiceName().isPresent() || oracleTask.getTnsAdminPath().isPresent()) {
                 throw new IllegalArgumentException("'tnsname', 'tnsname_path' parameters are invalid if 'url' parameter is set.");
             }
             url = oracleTask.getUrl().get();
-        } else if (oracleTask.getTnsname().isPresent() && oracleTask.getTnsnamePath().isPresent()) {
+        } else if (oracleTask.getNetServiceName().isPresent() && oracleTask.getTnsAdminPath().isPresent()) {
             if (oracleTask.getHost().isPresent() || oracleTask.getDatabase().isPresent()) {
                 throw new IllegalArgumentException("'host' and 'database' parameters are invalid if 'tnsname' and 'tnsname_path' parameters are set.");
             }
-            if (oracleTask.getUrl().isPresent()) {
-                throw new IllegalArgumentException("'url' parameter is invalid if 'tnsname' and 'tnsname_path' parameters are set.");
-            }
-            System.setProperty("oracle.net.tns_admin", oracleTask.getTnsnamePath().get());
-            logger.debug(String.format("Setting up env variable oracle.net.tns_admin to be %s", oracleTask.getTnsnamePath().get()));
-            url = String.format("jdbc:oracle:thin:@%s", oracleTask.getTnsname().get());
+            System.setProperty("oracle.net.tns_admin", oracleTask.getTnsAdminPath().get());
+            logger.debug(String.format("Setting up env variable oracle.net.tns_admin to be %s", oracleTask.getTnsAdminPath().get()));
+            url = String.format("jdbc:oracle:thin:@%s", oracleTask.getNetServiceName().get());
         } else {
             if (!oracleTask.getHost().isPresent()) {
                 throw new IllegalArgumentException("Field 'host' is not set.");


### PR DESCRIPTION
## Summary
Add support for oracle net service name when configuring embulk input.
```yaml
in:
  type: oracle 
  driver_path: <path of ojdbc7.jar>
  driver_class: oracle.jdbc.driver.OracleDriver
  tnsname_path:  <path of tnsname.ora location>
  tnsname:  <net service name e.g. ABC>
```

e.g. tnsname.ora 
```
ABC =
  (DESCRIPTION =
    (ENABLE = BROKEN)
    (ADDRESS_LIST =
      (ADDRESS = (PROTOCOL = TCP)(HOST = x.x.x.x)(PORT = 1524))
      (ADDRESS = (PROTOCOL = TCP)(HOST = x.x.x.x)(PORT = 1525))
      (LOAD_BALANCE = ON) 
      (FAILOVER = ON) 
    )   
    (CONNECT_DATA =
      (SERVICE_NAME = DEF)
      (SERVER = DEDICATED)
    )   
  )

```

## Issue
https://github.com/embulk/embulk-input-jdbc/issues/48
https://github.com/embulk/embulk-output-jdbc/issues/95

## Reviewer

@torihat 
@frsyuki 