### PR TITLE
Support ssl_version option

### DIFF
--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -19,6 +19,7 @@ PostgreSQL input plugin for Embulk loads records from PostgreSQL.
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **ssl**: enables SSL. data will be encrypted but CA or certification will not be verified (boolean, default: false)
+- **ssl_version**: specify SSL version (string, default: TLSv1.1(Java7), TLSv1.2(java8), Available values options are: `TLS`, `TLSv1.1`, `TLSv1.2`, `TLSv1.3`)
 - **application_name**: application name shown on pg_stat_activity. (string, default: "embulk-input-postgresql")
 - **options**: extra JDBC properties (hash, default: {})
 - If you write SQL directly,

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -6,6 +6,8 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import com.google.common.base.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -62,22 +64,39 @@ public class PostgreSQLInputPlugin
 
     public enum SslVersion
     {
-        TLS, TLSv1_1, TLSv1_2, TLSv1_3;
+        TLS("TLS"),
+        TLSv1_1("TLSv1.1"),
+        TLSv1_2("TLSv1.2"),
+        TLSv1_3("TLSv1.3");
+
+        private final String name;
+
+        SslVersion(final String name)
+        {
+            this.name = name;
+        }
+
+        @JsonCreator
+        public static SslVersion fromString(String from)
+        {
+            for (SslVersion version : SslVersion.values()) {
+                if (version.name.equals(from)) {
+                    return version;
+                }
+            }
+            throw new ConfigException(String.format("Unknown target '%s'. Supported ssl_version are [TLS, TLSv1.1, TLSv1.2, TLSv1.3]", from));
+        }
+
+        @JsonValue
+        @Override
+        public String toString()
+        {
+            return this.name;
+        }
 
         public String getVersion()
         {
-            switch (name()) {
-                case "TLS":
-                    return "TLS";
-                case "TLSv1_1":
-                    return "TLSv1.1";
-                case "TLSv1_2":
-                    return "TLSv1.2";
-                case "TLSv1_3":
-                    return "TLSv1.3";
-                default:
-                    throw new ConfigException(String.format("Unknown ssl_version '%s'. Supported auth_method are TLS, TLSv1_1, TLSv1_2, TLSv1_3", name()));
-            }
+            return toString();
         }
     }
 

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/MultiVersionSslFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/MultiVersionSslFactory.java
@@ -1,0 +1,63 @@
+/*-------------------------------------------------------------------------
+*
+* Copyright (c) 2004-2014, PostgreSQL Global Development Group
+*
+*
+*-------------------------------------------------------------------------
+*/
+package org.embulk.input.postgresql;
+
+import org.postgresql.ssl.WrappedFactory;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.X509TrustManager;
+import java.security.cert.X509Certificate;
+import java.security.GeneralSecurityException;
+
+/**
+ * sakama This class is based on 'org.postgresql.ssl.NonValidatingFactory' to support TLSv1.2/Java7
+ * We can remove this class when we migrate to Java8
+ *
+ * Provide a SSLSocketFactory that allows SSL connections to be
+ * made without validating the server's certificate.  This is more
+ * convenient for some applications, but is less secure as it allows
+ * "man in the middle" attacks.
+ */
+public class MultiVersionSslFactory extends WrappedFactory
+{
+    /**
+     * We provide a constructor that takes an unused argument solely
+     * because the ssl calling code will look for this constructor
+     * first and then fall back to the no argument constructor, so
+     * we avoid an exception and additional reflection lookups.
+     * @param arg SSLFactory argument
+     * @throws GeneralSecurityException same with NonValidatingFactory
+     */
+    public MultiVersionSslFactory(String arg) throws GeneralSecurityException
+    {
+        SSLContext ctx = SSLContext.getInstance(arg); // or "SSL" ?
+
+        ctx.init(null,
+                new TrustManager[] { new NonValidatingTM() },
+                null);
+
+        _factory = ctx.getSocketFactory();
+    }
+
+    public static class NonValidatingTM implements X509TrustManager
+    {
+
+        public X509Certificate[] getAcceptedIssuers() {
+            return new X509Certificate[0];
+        }
+
+        public void checkClientTrusted(X509Certificate[] certs, String authType)
+        {
+        }
+
+        public void checkServerTrusted(X509Certificate[] certs, String authType)
+        {
+        }
+    }
+}


### PR DESCRIPTION
I got `org.postgresql.util.PSQLException: SSL error: Connection reset` failure when using embulk-input-jdbc.

I'm using PostgreSQL9.3 and enables TLSv1.2.
I found this problem **only happens with Java7, never happens with Java8**.

My colleagues found this blog post.
> Java 7 and TLSv1.2 - supported, but not enabled by default
  http://fsanglier.blogspot.jp/2015/04/java-7-and-tlsv12-supported-but-not-enabled.html


I added `org.embulk.input.postgresql.MultiVersionSslFactory` based on `org.postgresql.ssl.NonValidatingFactory` to use with Java7.

Because `org.postgresql.ssl.NonValidatingFactory` only accepts TLS.
```java
public NonValidatingFactory(String arg) throws GeneralSecurityException {
        SSLContext ctx = SSLContext.getInstance("TLS"); // or "SSL" ?
```

### Stacktrace
```
2017-04-13 11:21:13.382 +0000 [WARN] (main): org.postgresql.util.PSQLException: SSL error: Connection reset
org.embulk.exec.PartialExecutionException: java.lang.RuntimeException: org.postgresql.util.PSQLException: SSL error: Connection reset
	at org.embulk.exec.BulkLoader$LoaderState.buildPartialExecuteException(BulkLoader.java:373) ~[embulk-core-0.8.18.jar:na]
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:591) ~[embulk-core-0.8.18.jar:na]
	at org.embulk.exec.BulkLoader.access$000(BulkLoader.java:33) ~[embulk-core-0.8.18.jar:na]
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:389) ~[embulk-core-0.8.18.jar:na]
	at org.embulk.exec.BulkLoader$1.run(BulkLoader.java:385) ~[embulk-core-0.8.18.jar:na]
	at org.embulk.spi.Exec.doWith(Exec.java:25) ~[embulk-core-0.8.18.jar:na]
	...
Caused by: java.lang.RuntimeException: org.postgresql.util.PSQLException: SSL error: Connection reset
	at com.google.common.base.Throwables.propagate(Throwables.java:160) ~[guava-18.0.jar:na]
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(AbstractJdbcInputPlugin.java:190) ~[na:na]
	at org.embulk.exec.BulkLoader.doRun(BulkLoader.java:528) ~[embulk-core-0.8.18.jar:na]
	... 15 common frames omitted
Caused by: org.postgresql.util.PSQLException: SSL error: Connection reset
	at org.postgresql.Driver$ConnectThread.getResult(Driver.java:365) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.Driver.connect(Driver.java:288) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.embulk.input.PostgreSQLInputPlugin.newConnection(PostgreSQLInputPlugin.java:93) ~[na:na]
	at org.embulk.input.PostgreSQLInputPlugin.newConnection(PostgreSQLInputPlugin.java:19) ~[na:na]
	at org.embulk.input.jdbc.AbstractJdbcInputPlugin.transaction(AbstractJdbcInputPlugin.java:186) ~[na:na]
	... 16 common frames omitted
Caused by: java.net.SocketException: Connection reset
	at java.net.SocketInputStream.read(SocketInputStream.java:196) ~[na:1.7.0_80]
	at java.net.SocketInputStream.read(SocketInputStream.java:122) ~[na:1.7.0_80]
	at sun.security.ssl.InputRecord.readFully(InputRecord.java:442) ~[na:1.7.0_80]
	at sun.security.ssl.InputRecord.read(InputRecord.java:480) ~[na:1.7.0_80]
	at sun.security.ssl.SSLSocketImpl.readRecord(SSLSocketImpl.java:934) ~[na:1.7.0_80]
	at sun.security.ssl.SSLSocketImpl.performInitialHandshake(SSLSocketImpl.java:1332) ~[na:1.7.0_80]
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1359) ~[na:1.7.0_80]
	at sun.security.ssl.SSLSocketImpl.startHandshake(SSLSocketImpl.java:1343) ~[na:1.7.0_80]
	at org.postgresql.ssl.jdbc4.AbstractJdbc4MakeSSL.convert(AbstractJdbc4MakeSSL.java:119) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.core.v3.ConnectionFactoryImpl.enableSSL(ConnectionFactoryImpl.java:339) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.core.v3.ConnectionFactoryImpl.openConnectionImpl(ConnectionFactoryImpl.java:133) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.core.ConnectionFactory.openConnection(ConnectionFactory.java:65) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.jdbc2.AbstractJdbc2Connection.<init>(AbstractJdbc2Connection.java:149) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.jdbc3.AbstractJdbc3Connection.<init>(AbstractJdbc3Connection.java:35) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.jdbc3g.AbstractJdbc3gConnection.<init>(AbstractJdbc3gConnection.java:22) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.jdbc4.AbstractJdbc4Connection.<init>(AbstractJdbc4Connection.java:47) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.jdbc4.Jdbc4Connection.<init>(Jdbc4Connection.java:30) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.Driver.makeConnection(Driver.java:414) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.Driver.access$100(Driver.java:47) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at org.postgresql.Driver$ConnectThread.run(Driver.java:325) ~[postgresql-9.3-1102-jdbc4.jar:na]
	at java.lang.Thread.run(Thread.java:745) ~[na:1.7.0_80]
```