### PR TITLE
Introduce `use_legacy_datetime_code` option for MySQL.

### DIFF
--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -1,7 +1,7 @@
 dependencies {
     compile project(':embulk-input-jdbc')
 
-    compile 'mysql:mysql-connector-java:5.1.34'
+    compile 'mysql:mysql-connector-java:5.1.41'
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -51,7 +51,7 @@ public class MySQLInputPlugin
         // https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-usagenotes-known-issues-limitations.html
         //
         @Config("use_legacy_datetime_code")
-        @ConfigDefault("true")
+        @ConfigDefault("false")
         public boolean getUseLegacyDatetimeCode();
 
     }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -51,7 +51,7 @@ public class MySQLInputPlugin
         // https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-usagenotes-known-issues-limitations.html
         //
         @Config("use_legacy_datetime_code")
-        @ConfigDefault("false")
+        @ConfigDefault("true")
         public boolean getUseLegacyDatetimeCode();
 
     }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -40,6 +40,20 @@ public class MySQLInputPlugin
 
         @Config("database")
         public String getDatabase();
+
+        //
+        // TODO
+        //
+        // The useLegacyDatetimeCode option is obsolete in the MySQL Connector/J 6.
+        // It will remove before we upgrade connector-j 6.x for embulk-input-mysql
+        //
+        // The `useLegacyDatetimeCode=false` option return properly time if server and client timezone is difference.
+        // https://dev.mysql.com/doc/connector-j/5.1/en/connector-j-usagenotes-known-issues-limitations.html
+        //
+        @Config("use_legacy_datetime_code")
+        @ConfigDefault("false")
+        public boolean getUseLegacyDatetimeCode();
+
     }
 
     @Override
@@ -72,6 +86,11 @@ public class MySQLInputPlugin
         // Enable keepalive based on tcp_keepalive_time, tcp_keepalive_intvl and tcp_keepalive_probes kernel parameters.
         // Socket options TCP_KEEPCNT, TCP_KEEPIDLE, and TCP_KEEPINTVL are not configurable.
         props.setProperty("tcpKeepAlive", "true");
+
+        // TODO
+        // The useLegacyDatetimeCode option is obsolete in the MySQL Connector/J 6.
+        // It will remove before we upgrade connector-j 6.x for embulk-input-mysql
+        props.setProperty("useLegacyDatetimeCode", String.valueOf(t.getUseLegacyDatetimeCode()));
 
         // TODO
         //switch task.getSssl() {


### PR DESCRIPTION
Fix #103

## Summaries

This is a PR for embulk-input-mysql plugin. 

### What is the problem to solve.

This change returns correctly time(server side time) even if client and server timezone is different. 

### How the existing implementation works.

Return incorrectly time if client and server timezone is different. 
A user need to set `option { useLegacyDatetimeCode: false }` explicitly. 

### Proposed change 

* Introduce new option `use_legacy_datetime_code`: (default: false)
* This change does not change current behavior if server and client use same timezone. 

## Reproduce procedure

If timezone parameter is a difference between server and client,
latest version(0.8.18) return wrong value. 

Proposed change return it properly. 

## Prepare test.

```
mysql> show variables like '%time_zone%';
+------------------+--------+
| Variable_name    | Value  |
+------------------+--------+
| system_time_zone | UTC    |
| time_zone        | SYSTEM |
+------------------+--------+
2 rows in set (0.00 sec)
```

```
mysql> select * from time_test;
+----+---------------------+---------------------+
| id | date_time           | time_stamp          |
+----+---------------------+---------------------+
|  1 | 2017-04-24 09:58:19 | 2017-04-24 09:58:19 |
+----+---------------------+---------------------+
1 row in set (0.01 sec)
```

```sql
create table time_test (id int not null, date_time datetime not null, time_stamp timestamp not null);
insert into time_test values(1,now(),now());
```

```
mysql> show fields from time_test;
+------------+-----------+------+-----+-------------------+-----------------------------+
| Field      | Type      | Null | Key | Default           | Extra                       |
+------------+-----------+------+-----+-------------------+-----------------------------+
| id         | int(11)   | NO   |     | NULL              |                             |
| date_time  | datetime  | NO   |     | NULL              |                             |
| time_stamp | timestamp | NO   |     | CURRENT_TIMESTAMP | on update CURRENT_TIMESTAMP |
+------------+-----------+------+-----+-------------------+-----------------------------+
3 rows in set (0.00 sec)
```

Client timezone is `JST` (+09:00)

## Latest version(0.8.18) behavior

### without option

```yaml
in:
  type: mysql
  table: time_test
  host: localhost
#  options: { useLegacyDatetimeCode: false }
  user: xxxx
  password: xxxx
  database: embulk_test
```

return wrong time.

```
+---------+-------------------------+-------------------------+
| id:long |     date_time:timestamp |    time_stamp:timestamp |
+---------+-------------------------+-------------------------+
|       1 | 2017-04-24 00:58:19 UTC | 2017-04-24 00:58:19 UTC |
+---------+-------------------------+-------------------------+
```

### with `options`

```yaml
in:
  type: mysql
  table: time_test
  host: localhost
  options: { useLegacyDatetimeCode: false }
  user: xxxx
  password: xxxx
  database: embulk_test
```

```
+---------+-------------------------+-------------------------+
| id:long |     date_time:timestamp |    time_stamp:timestamp |
+---------+-------------------------+-------------------------+
|       1 | 2017-04-24 09:58:19 UTC | 2017-04-24 09:58:19 UTC |
+---------+-------------------------+-------------------------+
```

## Proposed change

The `useLegacyDatetimeCode` option set to `false` by default. 

```yaml
in:
  type: mysql
  table: time_test
  host: localhost
  user: xxxx
  password: xxxx
  database: embulk_test
```

```
+---------+-------------------------+-------------------------+
| id:long |     date_time:timestamp |    time_stamp:timestamp |
+---------+-------------------------+-------------------------+
|       1 | 2017-04-24 09:58:19 UTC | 2017-04-24 09:58:19 UTC |
+---------+-------------------------+-------------------------+
```

### Compatibility option. 

```yaml
in:
  type: mysql
  table: time_test
  host: localhost
  user: xxxx
  password: xxxx
  database: embulk_test
  use_legacy_datetime_code: true
```

```
+---------+-------------------------+-------------------------+
| id:long |     date_time:timestamp |    time_stamp:timestamp |
+---------+-------------------------+-------------------------+
|       1 | 2017-04-24 00:58:19 UTC | 2017-04-24 00:58:19 UTC |
+---------+-------------------------+-------------------------+
```