### PR TITLE
[WIP] Output a version of MySQL Connector/J.

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -185,6 +185,7 @@ public abstract class AbstractJdbcInputPlugin
         Schema schema;
         try (JdbcInputConnection con = newConnection(task)) {
             // TODO incremental_columns is not set => get primary key
+            con.showDriverVersion();
             schema = setupTask(con, task);
         } catch (SQLException ex) {
             throw Throwables.propagate(ex);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -184,8 +184,9 @@ public abstract class AbstractJdbcInputPlugin
 
         Schema schema;
         try (JdbcInputConnection con = newConnection(task)) {
-            // TODO incremental_columns is not set => get primary key
             con.showDriverVersion();
+
+            // TODO incremental_columns is not set => get primary key
             schema = setupTask(con, task);
         } catch (SQLException ex) {
             throw Throwables.propagate(ex);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -388,7 +388,7 @@ public class JdbcInputConnection
         }
     }
 
-    void showDriverVersion(){
+    public void showDriverVersion(){
         try {
             DatabaseMetaData meta = connection.getMetaData();
             logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -7,6 +7,7 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Locale;
 import java.util.Set;
 
 import org.embulk.config.ConfigException;
@@ -384,6 +385,15 @@ public class JdbcInputConnection
                 columnNamesBuilder.add(rs.getString("COLUMN_NAME"));
             }
             return columnNamesBuilder.build();
+        }
+    }
+
+    void showDriverVersion(){
+        try {
+            DatabaseMetaData meta = connection.getMetaData();
+            logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));
+        } catch( SQLException e ) {
+            logger.warn(String.format(Locale.ENGLISH,"Can't get JDBC Driver version. Reason: %s",e.toString()));
         }
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -388,12 +388,8 @@ public class JdbcInputConnection
         }
     }
 
-    public void showDriverVersion(){
-        try {
-            DatabaseMetaData meta = connection.getMetaData();
-            logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));
-        } catch( SQLException e ) {
-            logger.warn(String.format(Locale.ENGLISH,"Can't get JDBC Driver version. Reason: %s",e.toString()));
-        }
+    public void showDriverVersion() throws SQLException {
+        DatabaseMetaData meta = connection.getMetaData();
+        logger.info(String.format(Locale.ENGLISH,"Using JDBC Driver %s",meta.getDriverVersion()));
     }
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -2,6 +2,7 @@ package org.embulk.input;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.util.Locale;
 import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
@@ -170,8 +171,28 @@ public class MySQLInputPlugin
     protected Schema setupTask(JdbcInputConnection con, PluginTask task) throws SQLException
     {
         MySQLInputConnection mySQLCon = (MySQLInputConnection)con;
+
+        showDriverVersion();
         mySQLCon.compareTimeZone();
         return super.setupTask(con,task);
+    }
+
+    private void showDriverVersion(){
+
+        Package aPackage = com.mysql.jdbc.Driver.class.getPackage();
+        String version = null;
+
+        if (aPackage != null) {
+            version = aPackage.getImplementationVersion();
+            if (version == null) {
+                version = aPackage.getSpecificationVersion();
+            }
+        }
+        if( version == null ){
+            logger.warn(String.format(Locale.ENGLISH,"Can't get driver version"));
+        } else {
+            logger.info(String.format(Locale.ENGLISH, "MySQL Connector/J version %s", version));
+        }
     }
 
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -2,7 +2,6 @@ package org.embulk.input;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.util.Locale;
 import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
@@ -171,28 +170,8 @@ public class MySQLInputPlugin
     protected Schema setupTask(JdbcInputConnection con, PluginTask task) throws SQLException
     {
         MySQLInputConnection mySQLCon = (MySQLInputConnection)con;
-
-        showDriverVersion();
         mySQLCon.compareTimeZone();
         return super.setupTask(con,task);
-    }
-
-    private void showDriverVersion(){
-
-        Package aPackage = com.mysql.jdbc.Driver.class.getPackage();
-        String version = null;
-
-        if (aPackage != null) {
-            version = aPackage.getImplementationVersion();
-            if (version == null) {
-                version = aPackage.getSpecificationVersion();
-            }
-        }
-        if( version == null ){
-            logger.warn(String.format(Locale.ENGLISH,"Can't get driver version"));
-        } else {
-            logger.info(String.format(Locale.ENGLISH, "MySQL Connector/J version %s", version));
-        }
     }
 
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -67,4 +67,16 @@ public class MySQLInputConnection
         timeZoneComparison.compareTimeZone();
     }
 
+    //
+    //
+    // The MySQL Connector/J 5.1.35 introduce new option `Current MySQL Connect`.
+    // It has incompatibility behavior current version and 5.1.35.
+    //
+    // This method announces users about this change before the update driver version.
+    //
+    @Override
+    public void showDriverVersion() {
+        super.showDriverVersion();
+        logger.warn("This plugin will update MySQL Connector/J version on next release...");
+    }
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -75,8 +75,10 @@ public class MySQLInputConnection
     // This method announces users about this change before the update driver version.
     //
     @Override
-    public void showDriverVersion() {
+    public void showDriverVersion() throws SQLException {
         super.showDriverVersion();
-        logger.warn("This plugin will update MySQL Connector/J version on next release...");
+        logger.warn("This plugin will update MySQL Connector/J version on a future release.");
+        logger.warn("It has some incompatibility change.");
+        logger.warn("Please read a document and make sure configuration carefully before update the plugin.");
     }
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -77,8 +77,9 @@ public class MySQLInputConnection
     @Override
     public void showDriverVersion() throws SQLException {
         super.showDriverVersion();
-        logger.warn("This plugin will update MySQL Connector/J version on a future release.");
-        logger.warn("It has some incompatibility change.");
-        logger.warn("Please read a document and make sure configuration carefully before update the plugin.");
+        logger.warn("This plugin will update MySQL Connector/J version in the near future release.");
+        logger.warn("It has some incompatibility changes.");
+        logger.warn("For example, the 5.1.35 introduced `noTimezoneConversionForDateType` and `cacheDefaultTimezone` options.");
+        logger.warn("Please read a document and make sure configuration carefully before updating the plugin.");
     }
 }


### PR DESCRIPTION
### Overview

I would like to update MySQL Connector/J to a newer version. (5.1.42 or newer)
But It has incompatibility change. 
We(I and @hito4t) decided that the plugin output a warning message like `This plugin will update Connector/J on next release...`
This PR for implement this warning. 

## Detail

@hito4t, Could you give me some advice?

- When output a version information and warning?
- How to output current Connector/J version.
  - How to get current Driver version (hard code, get version info from libraries)
- How to implement it. 

### When output a version information and warning?

I think I should the message should output before `Loaded plugin embulk/input/mysql from a load path`.

Example. 

```
2017-06-10 11:04:02.020 +0900: Embulk v0.8.22
2017-06-10 11:04:14.232 +0900 [INFO] (0001:preview): MySQL Connector/J version 5.1.34
2017-06-10 11:04:13.835 +0900 [INFO] (0001:preview): Loaded plugin embulk/input/mysql from a load path
.... and some warning message here
```

### How to output current Connector/J version?

I would like to output warning message with **current MySQL Connector/J version**.
So I tried to get it. 

The current experimental implementation get version info from `Package` object. 

First I tried to get the version info from `Driver` class. 
But It can't get sub minor version (z part in x.y.z). 
That's why I used this way. 

Do you have any alternative idea?

```java
Driver driver;
try {
    driver = new com.mysql.jdbc.Driver();

    int major = driver.getMajorVersion();
    int minor = driver.getMinorVersion();
    logger.info(String.format(Locale.ENGLISH,"driver version %d.%d",major,minor));
}
catch (SQLException e) {
    throw Throwables.propagate(e);
}
```
