### PR TITLE
Enabled to change MySQL JDBC driver 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -69,6 +69,7 @@ subprojects {
 
     configurations {
         provided
+        driver
     }
 
     sourceCompatibility = 1.7
@@ -110,10 +111,18 @@ subprojects {
 
     task classpath(type: Copy, dependsOn: ["jar"]) {
         doFirst { file('classpath').deleteDir() }
-        from (configurations.runtime - configurations.provided + files(jar.archivePath))
+        from (configurations.runtime - configurations.provided - configurations.driver + files(jar.archivePath))
         into 'classpath'
     }
-    clean { delete 'classpath' }
+    task driver(type: Copy, dependsOn: ["jar"]) {
+        doFirst { file('lib/embulk/driver').deleteDir() }
+        from (configurations.driver)
+        into 'lib/embulk/driver'
+    }
+    clean {
+        delete 'classpath'
+        delete 'lib/embulk/driver'
+    }
 
     checkstyle {
         configFile = file("${project.rootDir}/config/checkstyle/checkstyle.xml")
@@ -132,7 +141,7 @@ subprojects {
         source = sourceSets.main.allJava + sourceSets.test.allJava
     }
 
-    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath']) {
+    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath', 'driver']) {
         jrubyArgs '-rrubygems/gem_runner', "-eGem::GemRunner.new.run(ARGV)", 'build'
         scriptArgs "${project.projectDir.absolutePath}/build/gemspec"
         doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "${parent.projectDir}/pkg") }
@@ -186,7 +195,7 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["Apache 2.0"]
   spec.homepage      = "https://github.com/embulk/embulk-input-jdbc"
 
-  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"]
+  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"] + Dir["lib/embulk/driver/*.jar"]
   spec.test_files    = spec.files.grep(%r"^(test|spec)/")
   spec.require_paths = ["lib"]
 end

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ subprojects {
 
     configurations {
         provided
-        default_jdbc_driver
+        defaultJdbcDriver
     }
 
     sourceCompatibility = 1.7
@@ -111,12 +111,12 @@ subprojects {
 
     task classpath(type: Copy, dependsOn: ["jar"]) {
         doFirst { file('classpath').deleteDir() }
-        from (configurations.runtime - configurations.provided - configurations.default_jdbc_driver + files(jar.archivePath))
+        from (configurations.runtime - configurations.provided - configurations.defaultJdbcDriver + files(jar.archivePath))
         into 'classpath'
     }
-    task default_jdbc_driver(type: Copy, dependsOn: ["jar"]) {
+    task defaultJdbcDriver(type: Copy, dependsOn: ["jar"]) {
         doFirst { file('default_jdbc_driver').deleteDir() }
-        from (configurations.default_jdbc_driver)
+        from (configurations.defaultJdbcDriver)
         into 'default_jdbc_driver'
     }
     clean {
@@ -141,7 +141,7 @@ subprojects {
         source = sourceSets.main.allJava + sourceSets.test.allJava
     }
 
-    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath', 'default_jdbc_driver']) {
+    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath', 'defaultJdbcDriver']) {
         jrubyArgs '-rrubygems/gem_runner', "-eGem::GemRunner.new.run(ARGV)", 'build'
         scriptArgs "${project.projectDir.absolutePath}/build/gemspec"
         doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "${parent.projectDir}/pkg") }

--- a/build.gradle
+++ b/build.gradle
@@ -69,7 +69,7 @@ subprojects {
 
     configurations {
         provided
-        driver
+        default_jdbc_driver
     }
 
     sourceCompatibility = 1.7
@@ -111,17 +111,17 @@ subprojects {
 
     task classpath(type: Copy, dependsOn: ["jar"]) {
         doFirst { file('classpath').deleteDir() }
-        from (configurations.runtime - configurations.provided - configurations.driver + files(jar.archivePath))
+        from (configurations.runtime - configurations.provided - configurations.default_jdbc_driver + files(jar.archivePath))
         into 'classpath'
     }
-    task driver(type: Copy, dependsOn: ["jar"]) {
-        doFirst { file('lib/embulk/driver').deleteDir() }
-        from (configurations.driver)
-        into 'lib/embulk/driver'
+    task default_jdbc_driver(type: Copy, dependsOn: ["jar"]) {
+        doFirst { file('default_jdbc_driver').deleteDir() }
+        from (configurations.default_jdbc_driver)
+        into 'default_jdbc_driver'
     }
     clean {
         delete 'classpath'
-        delete 'lib/embulk/driver'
+        delete 'default_jdbc_driver'
     }
 
     checkstyle {
@@ -141,7 +141,7 @@ subprojects {
         source = sourceSets.main.allJava + sourceSets.test.allJava
     }
 
-    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath', 'driver']) {
+    task gem(type: JRubyExec, dependsOn: ['build', 'gemspec', 'classpath', 'default_jdbc_driver']) {
         jrubyArgs '-rrubygems/gem_runner', "-eGem::GemRunner.new.run(ARGV)", 'build'
         scriptArgs "${project.projectDir.absolutePath}/build/gemspec"
         doLast { ant.move(file: "${project.name}-${project.version}.gem", todir: "${parent.projectDir}/pkg") }
@@ -195,7 +195,7 @@ Gem::Specification.new do |spec|
   spec.licenses      = ["Apache 2.0"]
   spec.homepage      = "https://github.com/embulk/embulk-input-jdbc"
 
-  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"] + Dir["lib/embulk/driver/*.jar"]
+  spec.files         = `git ls-files`.split("\n") + Dir["classpath/*.jar"] + Dir["default_jdbc_driver/*.jar"]
   spec.test_files    = spec.files.grep(%r"^(test|spec)/")
   spec.require_paths = ["lib"]
 end

--- a/embulk-input-db2/build.gradle
+++ b/embulk-input-db2/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     compile project(':embulk-input-jdbc')
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
-    testCompile files('driver/db2jcc4.jar')
+    testCompile files('test_jdbc_driver/db2jcc4.jar')
 }

--- a/embulk-input-db2/src/test/java/org/embulk/input/db2/DB2Tests.java
+++ b/embulk-input-db2/src/test/java/org/embulk/input/db2/DB2Tests.java
@@ -21,6 +21,12 @@ public class DB2Tests
 
     public static void execute(String sqlName) throws Exception
     {
+        try {
+            Class.forName("com.ibm.db2.jcc.DB2Driver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("You should put 'db2jcc4.jar' in 'embulk-input-db2/test_jdbc_driver' directory in order to test.");
+        }
+
         // DB2Tests.excute takes a resource name of SQL file, doesn't take a SQL sentence as other XXXTests do.
         // Because TestingEmbulk.createTempFile might create a file whose name contains ' ' and DB2 clpplus cannot read such a file.
         // But if root directory name of embulk-input-db2 contains ' ', tests will fail for the same reason.

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -1,5 +1,9 @@
 package org.embulk.input.jdbc;
 
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
@@ -14,7 +18,6 @@ import com.google.common.base.Optional;
 import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigException;
@@ -593,4 +596,28 @@ public abstract class AbstractJdbcInputPlugin
         }
         loader.addPath(Paths.get(glob));
     }
+
+    protected File findPluginRoot()
+    {
+        try {
+            URL url = getClass().getResource("/" + getClass().getName().replace('.', '/') + ".class");
+            if (url.toString().startsWith("jar:")) {
+                url = new URL(url.toString().replaceAll("^jar:", "").replaceAll("![^!]*$", ""));
+            }
+
+            File folder = new File(url.toURI()).getParentFile();
+            for (;; folder = folder.getParentFile()) {
+                if (folder == null) {
+                    throw new RuntimeException("Cannot find 'embulk-input-xxx' folder.");
+                }
+
+                if (folder.getName().startsWith("embulk-input-")) {
+                    return folder;
+                }
+            }
+        } catch (MalformedURLException | URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
 }

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -9,6 +9,7 @@ MySQL input plugin for Embulk loads records from MySQL.
 
 ## Configuration
 
+- **driver_path**: path to the jar file of the MySQL JDBC driver. If not set, the bundled JDBC driver (MySQL Connector/J 5.1.34) will be used. (string)
 - **host**: database host name (string, required)
 - **port**: database port number (integer, 3306)
 - **user**: database login user name (string, required)

--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -2,6 +2,7 @@ dependencies {
     compile project(':embulk-input-jdbc')
 
     compile 'mysql:mysql-connector-java:5.1.34'
+    driver 'mysql:mysql-connector-java:5.1.34'
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
 }

--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':embulk-input-jdbc')
 
     compile 'mysql:mysql-connector-java:5.1.34'
-    default_jdbc_driver 'mysql:mysql-connector-java:5.1.34'
+    defaultJdbcDriver 'mysql:mysql-connector-java:5.1.34'
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
 }

--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -2,7 +2,7 @@ dependencies {
     compile project(':embulk-input-jdbc')
 
     compile 'mysql:mysql-connector-java:5.1.34'
-    driver 'mysql:mysql-connector-java:5.1.34'
+    default_jdbc_driver 'mysql:mysql-connector-java:5.1.34'
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -76,7 +76,7 @@ public class MySQLInputPlugin
 
             } catch (ClassNotFoundException ex) {
                 File root = findPluginRoot();
-                File driverLib = new File(new File(new File(root, "lib"), "embulk"), "driver");
+                File driverLib = new File(root, "default_jdbc_driver");
                 File[] files = driverLib.listFiles(new FileFilter() {
                     @Override
                     public boolean accept(File file) {

--- a/embulk-input-oracle/build.gradle
+++ b/embulk-input-oracle/build.gradle
@@ -2,5 +2,5 @@ dependencies {
     compile project(':embulk-input-jdbc')
 
     testCompile 'org.embulk:embulk-standards:0.8.15'
-    testCompile files('driver/ojdbc7.jar')
+    testCompile files('test_jdbc_driver/ojdbc7.jar')
 }

--- a/embulk-input-oracle/src/test/java/org/embulk/input/oracle/OracleTests.java
+++ b/embulk-input-oracle/src/test/java/org/embulk/input/oracle/OracleTests.java
@@ -2,6 +2,7 @@ package org.embulk.input.oracle;
 
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
+
 import org.embulk.config.ConfigSource;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
@@ -22,7 +23,13 @@ public class OracleTests
     }
 
     public static void execute(TestingEmbulk embulk, String sql) throws IOException
-{
+    {
+        try {
+            Class.forName("oracle.jdbc.OracleDriver");
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException("You should put 'ojdbc7.jar' in 'embulk-input-oracle/test_jdbc_driver' directory in order to test.");
+        }
+
         Path sqlFile = embulk.createTempFile("sql");
         Files.write(sqlFile, Arrays.asList(sql), Charset.forName("UTF8"));
 


### PR DESCRIPTION
Users can use MySQL JDBC driver other than bundled JDBC driver.
We will upgrade bundled JDBC driver, but users could use old JDBC driver for compatibility.
Or users could use newer JDBC driver before bundled JDBC driver is upgraded.