### PR TITLE
Support array column type

### DIFF
--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -35,7 +35,7 @@ PostgreSQL input plugin for Embulk loads records from PostgreSQL.
 - **default_timezone**: If the sql type of a column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted int this default_timezone. You can overwrite timezone for each columns using column_options option. (string, default: `UTC`)
 - **column_options**: advanced: a key-value pairs where key is a column name and value is options for the column.
   - **value_type**: embulk get values from database as this value_type. Typically, the value_type determines `getXXX` method of `java.sql.PreparedStatement`.
-  (string, default: depends on the sql type of the column. Available values options are: `long`, `double`, `float`, `decimal`, `boolean`, `string`, `json`, `date`, `time`, `timestamp`)
+  (string, default: depends on the sql type of the column. Available values options are: `long`, `double`, `float`, `decimal`, `boolean`, `string`, `json`, `date`, `time`, `timestamp`, `array`)
   See below for `hstore` column.
   - **type**: Column values are converted to this embulk type.
   Available values options are: `boolean`, `long`, `double`, `string`, `json`, `timestamp`).
@@ -60,6 +60,24 @@ In addition, `json` type is supported for `hstore` column, and output will be as
 
 `value_type` is ignored.
 
+### Arrays column support
+
+PostgreSQL allows columns of a table to be defined as variable-length multidimensional arrays and this plugin supports converting its value into `string` or `json`.
+
+By default, `type` of `column_options` for `array` column is `string`, and output will be similar to what `psql` produces:
+```
+    {1000,2000,3000,4000}, {{red,green},{blue,cyan}}
+    {5000,6000,7000,8000}, {{yellow,magenta},{purple,"light,dark"}}
+```
+
+Output of `json` type will be as follow:
+```
+[1000,2000,3000,4000],[["red","green"],["blue","cyan"]]
+[5000,6000,7000,8000],[["yellow","magenta"],["purple"","light,dark"]]
+```
+However, the support for `json` type has the following limitations:
+- Postgres server version must be 8.3.0 and above
+- The value type of array element must be number, bool, or text, e.g. bool[], integer[], text[][], bigint[][][]...
 
 ### Incremental loading
 

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/ArrayColumnGetter.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/ArrayColumnGetter.java
@@ -1,0 +1,104 @@
+package org.embulk.input.postgresql.getter;
+
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.NullNode;
+import org.embulk.input.jdbc.getter.AbstractColumnGetter;
+import org.embulk.spi.Column;
+import org.embulk.spi.PageBuilder;
+import org.embulk.spi.json.JsonParseException;
+import org.embulk.spi.json.JsonParser;
+import org.embulk.spi.type.Type;
+import org.msgpack.value.Value;
+
+import java.sql.Array;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+
+import java.sql.Types;
+
+public class ArrayColumnGetter
+        extends AbstractColumnGetter
+{
+    protected Array value;
+
+    protected final JsonParser jsonParser = new JsonParser();
+
+    public ArrayColumnGetter(PageBuilder to, Type toType)
+    {
+        super(to, toType);
+    }
+
+    @Override
+    protected void fetch(ResultSet from, int fromIndex) throws SQLException
+    {
+        value = from.getArray(fromIndex);
+    }
+
+    private ArrayNode buildJsonArray(Object[] elements)
+            throws SQLException
+    {
+        ArrayNode arrayNode = jsonNodeFactory.arrayNode();
+        for (Object v : elements) {
+            if (v == null) {
+                arrayNode.add(NullNode.getInstance());
+                continue;
+            }
+            if (v.getClass().isArray()) {
+                arrayNode.add(buildJsonArray((Object[]) v));
+            }
+            else {
+                switch (value.getBaseType()) {
+                    case Types.TINYINT:
+                    case Types.SMALLINT:
+                    case Types.INTEGER:
+                    case Types.BIGINT:
+                        arrayNode.add(jsonNodeFactory.numberNode(((Number) v).longValue()));
+                        break;
+                    case Types.FLOAT:
+                    case Types.REAL:
+                    case Types.DOUBLE:
+                        arrayNode.add(jsonNodeFactory.numberNode(((Number) v).doubleValue()));
+                        break;
+                    case Types.BOOLEAN:
+                    case Types.BIT:  // JDBC BIT is boolean, unlike SQL-92
+                        arrayNode.add(jsonNodeFactory.booleanNode((Boolean) v));
+                        break;
+                    case Types.CHAR:
+                    case Types.VARCHAR:
+                    case Types.LONGVARCHAR:
+                    case Types.CLOB:
+                    case Types.NCHAR:
+                    case Types.NVARCHAR:
+                    case Types.LONGNVARCHAR:
+                        arrayNode.add(jsonNodeFactory.textNode((String) v));
+                        break;
+                }
+            }
+        }
+        return arrayNode;
+    }
+
+    @Override
+    protected Type getDefaultToType()
+    {
+        return org.embulk.spi.type.Types.STRING;
+    }
+
+    @Override
+    public void jsonColumn(Column column)
+    {
+        try {
+            Value v = jsonParser.parse(buildJsonArray((Object[]) value.getArray()).toString());
+            to.setJson(column, v);
+        }
+        catch (JsonParseException | SQLException | ClassCastException e) {
+            super.jsonColumn(column);
+        }
+    }
+
+    @Override
+    public void stringColumn(Column column)
+    {
+        to.setString(column, value.toString());
+    }
+}

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -27,6 +27,10 @@ public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
             return new HstoreToJsonColumnGetter(to, Types.JSON);
         }
 
+        if (column.getSqlType() == java.sql.Types.ARRAY) {
+            return new ArrayColumnGetter(to, getToType(option));
+        }
+
         ColumnGetter getter = super.newColumnGetter(con, task, column, option);
 
         // incremental loading wrapper
@@ -48,7 +52,8 @@ public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
         case "jsonb":
             return "json";
         case "hstore":
-            // hstore is converted to string by default
+        case "array":
+            // array & hstore is converted to string by default
             return "string";
         default:
             return super.sqlTypeToValueType(column, sqlType);

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
@@ -1,0 +1,74 @@
+package org.embulk.input.postgresql;
+
+import org.embulk.config.ConfigSource;
+import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.spi.InputPlugin;
+import org.embulk.test.EmbulkTests;
+import org.embulk.test.TestingEmbulk;
+import org.embulk.test.TestingEmbulk.RunResult;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.embulk.input.postgresql.PostgreSQLTests.execute;
+import static org.embulk.test.EmbulkTests.readSortedFile;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThat;
+
+public class ArrayTest
+{
+    private static final String BASIC_RESOURCE_PATH = "org/embulk/input/postgresql/test/expect/array/";
+
+    private static ConfigSource loadYamlResource(TestingEmbulk embulk, String fileName)
+    {
+        return embulk.loadYamlResource(BASIC_RESOURCE_PATH + fileName);
+    }
+
+    private static String readResource(String fileName)
+    {
+        return EmbulkTests.readResource(BASIC_RESOURCE_PATH + fileName);
+    }
+
+    @Rule
+    public TestingEmbulk embulk = TestingEmbulk.builder()
+        .registerPlugin(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class)
+        .build();
+
+    private ConfigSource baseConfig;
+
+    @Before
+    public void setup()
+    {
+        baseConfig = PostgreSQLTests.baseConfig();
+    }
+
+    @Test
+    public void loadAsStringByDefault() throws Exception
+    {
+        execute(readResource("setup.sql"));
+
+        Path out1 = embulk.createTempFile("csv");
+        embulk.runInput(
+                baseConfig.merge(loadYamlResource(embulk, "as_string.yml")),
+                out1);
+        assertThat(
+                readSortedFile(out1),
+                is(readResource("expected_string.csv")));
+    }
+
+    @Test
+    public void loadAsJson() throws Exception
+    {
+        execute(readResource("setup.sql"));
+
+        Path out1 = embulk.createTempFile("csv");
+        embulk.runInput(
+                baseConfig.merge(loadYamlResource(embulk, "as_json.yml")),
+                out1);
+        assertThat(
+                readSortedFile(out1),
+                is(readResource("expected_json.csv")));
+    }
+}

--- a/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/as_json.yml
+++ b/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/as_json.yml
@@ -1,0 +1,5 @@
+table: input_array
+column_options:
+  c1: {type: json}
+  c2: {type: json}
+  c3: {type: json}

--- a/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/as_string.yml
+++ b/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/as_string.yml
@@ -1,0 +1,1 @@
+table: input_array

--- a/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/expected_json.csv
+++ b/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/expected_json.csv
@@ -1,0 +1,2 @@
+"[1000,2000,3000,4000]","[[""red"",""green""],[""blue"",""cyan""]]",[[[true]]]
+"[5000,6000,7000,8000]","[[""yellow"",""magenta""],[""purple"",""light,dark""]]","[[[true,true],[false,false]],[[true,false],[false,true]]]"

--- a/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/expected_string.csv
+++ b/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/expected_string.csv
@@ -1,0 +1,2 @@
+"{1000,2000,3000,4000}","{{red,green},{blue,cyan}}",{{{t}}}
+"{5000,6000,7000,8000}","{{yellow,magenta},{purple,""light,dark""}}","{{{t,t},{f,f}},{{t,f},{f,t}}}"

--- a/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/setup.sql
+++ b/embulk-input-postgresql/src/test/resources/org/embulk/input/postgresql/test/expect/array/setup.sql
@@ -1,0 +1,11 @@
+drop table if exists input_array;
+
+create table input_array (
+    c1 integer[],
+    c2 text[][],
+    c3 bool[][][]
+);
+
+insert into input_array (c1, c2, c3) values ('{1000, 2000, 3000, 4000}', '{{"red", "green"}, {"blue", "cyan"}}', '{{{true}}}');
+
+insert into input_array (c1, c2, c3) values ('{5000, 6000, 7000, 8000}', '{{"yellow", "magenta"}, {"purple", "light,dark"}}', '{{{t,t},{f,f}},{{t,f},{f,t}}}');


### PR DESCRIPTION
This PR implements `array` column type support for Postgres.

The implementation supports converting both single/multiple dimension array to string & json. However, in json case, only simple value types (number, bool, and text) are allowed in the array elements, e.g. integer[], text[][], bigint[][][]...

The implementation does have a compatible limitation. It works perfectly for Postgres server version 8.3.0 and above due to the usage of object type versus primitive type for array elements. This can be fixed but it would introduce a very complex code base.