### PR TITLE
Use traditional constructors of TimestampFormatter and TimestampParser against deprecation: Fix #118

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -7,7 +7,6 @@ import org.embulk.config.Task;
 import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
-import org.jruby.embed.ScriptingContainer;
 
 import com.google.common.base.Optional;
 
@@ -29,8 +28,4 @@ public interface JdbcColumnOption
     @Config("timezone")
     @ConfigDefault("null")
     public Optional<DateTimeZone> getTimeZone();
-
-    // required by TimestampFormatter
-    @ConfigInject
-    public ScriptingContainer getJRuby();
 }


### PR DESCRIPTION
Trying to workaround the deprecation on the Embulk core side.

@hito4t @muga Can you have a look?