### PR TITLE
fix "datetime" type timezone convert support

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -60,6 +60,8 @@ public class ColumnGetterFactory
             return new JsonColumnGetter(to, toType);
         case "date":
             return new DateColumnGetter(to, toType, newTimestampFormatter(option, DateColumnGetter.DEFAULT_FORMAT));
+        case "datetime":
+            return new DateColumnGetter(to, toType, newTimestampFormatter(option, DateColumnGetter.DEFAULT_FORMAT));
         case "time":
             return new TimeColumnGetter(to, toType, newTimestampFormatter(option, DateColumnGetter.DEFAULT_FORMAT));
         case "timestamp":


### PR DESCRIPTION
sqlserver's datetime field cannot convert timezone Asia/Seoul to UTC

