### PR TITLE
Add table hint option to sqlserver plugin.

### DIFF
--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -27,6 +27,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
+  - **table_hint**: table hint (e.g. `NOLOCK`) (string, optional)
   - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
   - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -27,7 +27,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **query**: SQL to run (string)
 - If **query** is not set,
   - **table**: destination table name (string, required)
-  - **table_hint**: table hint (e.g. `NOLOCK`) (string, optional)
+  - **transaction_isolation_level**: transaction isolation level. (e.g. `NOLOCK`) (string, optional)
   - **select**: expression of select (e.g. `id, created_at`) (string, default: "*")
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
   - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -64,6 +64,10 @@ public class SQLServerInputPlugin
         @ConfigDefault("null")
         public Optional<String> getSchema();
 
+        @Config("table_hint")
+        @ConfigDefault("null")
+        public Optional<String> getTableHint();
+
         @Config("application_name")
         @ConfigDefault("\"embulk-input-sqlserver\"")
         @Size(max=128)
@@ -134,7 +138,8 @@ public class SQLServerInputPlugin
 
         Connection con = driver.connect(urlAndProps.getUrl(), props);
         try {
-            SQLServerInputConnection c = new SQLServerInputConnection(con, sqlServerTask.getSchema().orNull());
+            SQLServerInputConnection c = new SQLServerInputConnection(con, sqlServerTask.getSchema().orNull(),
+                                                                      sqlServerTask.getTableHint().orNull());
             con = null;
             return c;
         }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -64,9 +64,9 @@ public class SQLServerInputPlugin
         @ConfigDefault("null")
         public Optional<String> getSchema();
 
-        @Config("table_hint")
+        @Config("transaction_isolation_level")
         @ConfigDefault("null")
-        public Optional<String> getTableHint();
+        public Optional<String> getTransactionIsolationLevel();
 
         @Config("application_name")
         @ConfigDefault("\"embulk-input-sqlserver\"")
@@ -139,7 +139,7 @@ public class SQLServerInputPlugin
         Connection con = driver.connect(urlAndProps.getUrl(), props);
         try {
             SQLServerInputConnection c = new SQLServerInputConnection(con, sqlServerTask.getSchema().orNull(),
-                                                                      sqlServerTask.getTableHint().orNull());
+                                                                      sqlServerTask.getTransactionIsolationLevel().orNull());
             con = null;
             return c;
         }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
@@ -6,9 +6,17 @@ import org.embulk.input.jdbc.JdbcInputConnection;
 
 public class SQLServerInputConnection extends JdbcInputConnection {
 
+    private String tableHint;
+
     public SQLServerInputConnection(Connection connection, String schemaName) throws SQLException
     {
         super(connection, schemaName);
+    }
+
+    public SQLServerInputConnection(Connection connection, String schemaName, String tableHint) throws SQLException
+    {
+        super(connection, schemaName);
+        this.tableHint = tableHint;
     }
 
     @Override
@@ -25,6 +33,9 @@ public class SQLServerInputConnection extends JdbcInputConnection {
             sb.append(quoteIdentifierString(schemaName)).append(".");
         }
         sb.append(quoteIdentifierString(tableName));
+        if (tableHint != null) {
+            sb.append(" with (" + tableHint + ")");
+        }
         return sb.toString();
     }
 

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
@@ -6,17 +6,18 @@ import org.embulk.input.jdbc.JdbcInputConnection;
 
 public class SQLServerInputConnection extends JdbcInputConnection {
 
-    private String tableHint;
+    private String transactionIsolationLevel;
 
     public SQLServerInputConnection(Connection connection, String schemaName) throws SQLException
     {
         super(connection, schemaName);
     }
 
-    public SQLServerInputConnection(Connection connection, String schemaName, String tableHint) throws SQLException
+    public SQLServerInputConnection(Connection connection, String schemaName, String transactionIsolationLevel)
+            throws SQLException
     {
         super(connection, schemaName);
-        this.tableHint = tableHint;
+        this.transactionIsolationLevel = transactionIsolationLevel;
     }
 
     @Override
@@ -33,8 +34,8 @@ public class SQLServerInputConnection extends JdbcInputConnection {
             sb.append(quoteIdentifierString(schemaName)).append(".");
         }
         sb.append(quoteIdentifierString(tableName));
-        if (tableHint != null) {
-            sb.append(" with (" + tableHint + ")");
+        if (transactionIsolationLevel != null) {
+            sb.append(" with (" + transactionIsolationLevel + ")");
         }
         return sb.toString();
     }


### PR DESCRIPTION

```
in:
・・・
  table: TABLE_NAME
  table_hint: NOLOCK
  where: "updated_at <= DATEADD(hour, -1, getdate())"
・・・
```

The above configuration generates following SQL:

```
SELECT * FROM "TABLE_NAME" with (NOLOCK) WHERE updated_at <= DATEADD(hour, -1, getdate())
```