### PR TITLE
Support datetime type column of SQLServer for incremental_columns option.

### DIFF
--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -11,9 +11,14 @@ import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
+import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.sqlserver.SQLServerInputConnection;
 
 import com.google.common.base.Optional;
+import org.embulk.input.sqlserver.getter.SQLServerColumnGetterFactory;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
+
 import static java.util.Locale.ENGLISH;
 
 public class SQLServerInputPlugin
@@ -143,6 +148,12 @@ public class SQLServerInputPlugin
                 con.close();
             }
         }
+    }
+
+    @Override
+    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    {
+        return new SQLServerColumnGetterFactory(pageBuilder, dateTimeZone);
     }
 
     private UrlAndProperties buildUrlAndProperties(SQLServerPluginTask sqlServerTask, boolean useJtdsDriver)

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
@@ -1,0 +1,30 @@
+package org.embulk.input.sqlserver.getter;
+
+import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
+import org.embulk.input.jdbc.JdbcColumn;
+import org.embulk.input.jdbc.JdbcColumnOption;
+import org.embulk.input.jdbc.JdbcInputConnection;
+import org.embulk.input.jdbc.getter.*;
+import org.embulk.spi.PageBuilder;
+import org.joda.time.DateTimeZone;
+
+public class SQLServerColumnGetterFactory extends ColumnGetterFactory {
+
+    public SQLServerColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    {
+        super(to, defaultTimeZone);
+    }
+
+    @Override
+    public ColumnGetter newColumnGetter(JdbcInputConnection con, AbstractJdbcInputPlugin.PluginTask task, JdbcColumn column, JdbcColumnOption option)
+    {
+        ColumnGetter getter = super.newColumnGetter(con, task, column, option);
+        switch (column.getTypeName()) {
+            case "datetime":
+                return new TimestampWithoutTimeZoneIncrementalHandler(getter);
+            default:
+                return getter;
+        }
+    }
+
+}


### PR DESCRIPTION
This is just for embulk-input-sqlserver.

If `incremental_columns` option is filled with datetime type column, the exception with following message comes out in v0.9.1.

> Column type 'timestamp' set at `incremental_columns` option is not supported

The columns whose type is datetime is supported as `incremental_columns` option by this PR.
