### PR TITLE
Added `before_select` to Redshift config

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -720,6 +720,6 @@ public abstract class AbstractJdbcInputPlugin
                 maskedProps.setProperty(key, props.getProperty(key));
             }
         }
-        logger.info("Connecting2 to {} options {}", url, maskedProps);
+        logger.info("Connecting to {} options {}", url, maskedProps);
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -151,6 +151,10 @@ public abstract class AbstractJdbcInputPlugin
         @ConfigDefault("{}")
         public Map<String, JdbcColumnOption> getDefaultColumnOptions();
 
+        @Config("before_select")
+        @ConfigDefault("null")
+        public Optional<String> getBeforeSelect();
+
         @Config("after_select")
         @ConfigDefault("null")
         public Optional<String> getAfterSelect();
@@ -196,6 +200,12 @@ public abstract class AbstractJdbcInputPlugin
         Schema schema;
         try (JdbcInputConnection con = newConnection(task)) {
             con.showDriverVersion();
+
+            if (task.getBeforeSelect().isPresent()) {
+                con.executeUpdate(task.getBeforeSelect().get());
+                con.connection.commit();
+                logger.info("Executed before_select query");
+            }
 
             // TODO incremental_columns is not set => get primary key
             schema = setupTask(con, task);
@@ -710,6 +720,6 @@ public abstract class AbstractJdbcInputPlugin
                 maskedProps.setProperty(key, props.getProperty(key));
             }
         }
-        logger.info("Connecting to {} options {}", url, maskedProps);
+        logger.info("Connecting2 to {} options {}", url, maskedProps);
     }
 }

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -43,6 +43,7 @@ Redshift input plugin for Embulk loads records from Redshift.
   - **timezone**: If the sql type of the column is `date`/`time`/`datetime` and the embulk type is `string`, column values are formatted in this timezone.
 (string, value of default_timezone option is used by default)
 - **after_select**: if set, this SQL will be executed after the SELECT query in the same transaction.
+- **before_select**: if set, this SQL will be executed before the SELECT query in the same transaction.
 
 
 ### Incremental loading


### PR DESCRIPTION
- `redshift-input-plugin` has new field called `before_select`. SQL query written in field will be executed just before select `query` executed.
- Field can be used to do inserts, create temp tables or any other use case where data is not getting returned.
- In Redshift ideally temp tables should be created with `CREATE TEMP TABLE` syntax. We can specify sort key and dist keys in mentioned way.