### PR TITLE
Update description about TIMESTAMP or related type columns as incremental column

### DIFF
--- a/embulk-input-jdbc/README.md
+++ b/embulk-input-jdbc/README.md
@@ -77,6 +77,8 @@ CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 
 Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment primary key. Currently, only strings and integers are supported as incremental_columns.
 
+TIMESTAMP, TIMESTAMPTZ, DATE and DATETIME are also supported depends on each RDBMS
+
 ### Use incremental loading with raw query
 
 **IMPORTANT**: This is an advanced feature and assume you have an enough knowledge about incremental loading using Embulk and this plugin

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -86,7 +86,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an AUTO_INCREMENT primary key. Currently, only strings, integers, DATETIME and TIMESTAMP are supported as incremental_columns.
 
 
 ## Trouble shooting

--- a/embulk-input-oracle/README.md
+++ b/embulk-input-oracle/README.md
@@ -80,7 +80,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds a primary key. Currently, only strings, integers, DATE and TIMESTAMP are supported as incremental_columns.
 
 ### Use incremental loading with raw query
 

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -113,7 +113,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (serial / bigserial) primary key. Currently, only strings, integers, TIMESTAMP and TIMESTAMPTZ are supported as incremental_columns.
 
 ### Use incremental loading with raw query
 

--- a/embulk-input-redshift/README.md
+++ b/embulk-input-redshift/README.md
@@ -78,7 +78,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an auto-increment (IDENTITY) primary key. Currently, only strings, integers, TIMESTAMP and TIMESTAMPTZ are supported as incremental_columns.
 
 ### Use incremental loading with raw query
 

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -86,7 +86,7 @@ Then, it updates `last_record: ` so that next execution uses the updated last_re
 CREATE INDEX embulk_incremental_loading_index ON table (updated_at, id);
 ```
 
-Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key. Currently, only strings and integers are supported as incremental_columns.
+Recommended usage is to leave `incremental_columns` unset and let this plugin automatically finds an IDENTITY primary key. Currently, only strings, integers and DATETIME are supported as incremental_columns.
 
 ### Use incremental loading with raw query
 


### PR DESCRIPTION
Currently TIMESTAMP or related type columns are also supported as incremental column.
README is bit old.

* MySQL
  * [DATETIME](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java#L52)
  * [TIMESTAMP](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java#L55)

* Oracle
  * [DATE](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java#L27)
  * [TIMESTAMP](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java#L30)

* PostgreSQL
  * [TIMESTAMPTZ](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java#L43)
  * [TIMESTAMP](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java#L45)

* Redshift
  * [TIMESTAMPTZ](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java#L28)
  * [TIMESTAMP](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java#L30)

* SQL Server
  * [DATETIME](https://github.com/embulk/embulk-input-jdbc/blob/v0.9.3/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java#L23)