### PR TITLE
Use Docker for MySQL and PostgreSQL unit tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,5 @@ classpath/
 build/
 .idea
 /out/
-ci/postgresql.yml
 
 embulk-input-oracle/driver/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,27 +1,22 @@
 language: java
 dist: trusty
 sudo: required
-addons:
-  postgresql: "9.4"
-  apt:
-    packages:
-      - mysql-server-5.6
-      - mysql-client-core-5.6
-      - mysql-client-5.6
 services:
-  - postgresql
+  - docker
 jdk:
   - oraclejdk8
+
 env:
   global:
-    - EMBULK_INPUT_POSTGRESQL_TEST_CONFIG=$TRAVIS_BUILD_DIR/ci/travis_postgresql.yml
-    - EMBULK_INPUT_MYSQL_TEST_CONFIG=$TRAVIS_BUILD_DIR/ci/travis_mysql.yml
+    - EMBULK_INPUT_POSTGRESQL_TEST_CONFIG=$TRAVIS_BUILD_DIR/ci/postgresql.yml
+    - EMBULK_INPUT_MYSQL_TEST_CONFIG=$TRAVIS_BUILD_DIR/ci/mysql.yml
 cache:
   directories:  # run "travis cache --delete" to delete caches
     - $HOME/.gradle
+
 before_script:
-  - psql -c "create database travis_ci_test;" -U postgres
-  - mysql -u root -e "create database travis_ci_test;"
-  - mysql -u root -e "grant all on travis_ci_test.* to travis@localhost identified by '';" # give 'travis' user grant to create/drop tables.
+  - docker-compose up -d
+  - docker-compose ps
+
 script:
   - ./gradlew --info check

--- a/ci/mysql.yml
+++ b/ci/mysql.yml
@@ -1,0 +1,6 @@
+type: mysql
+host: 127.0.0.1
+port: 13306
+database: ci_test
+user: test
+password: test

--- a/ci/postgresql.yml
+++ b/ci/postgresql.yml
@@ -1,0 +1,6 @@
+type: postgresql
+host: 127.0.0.1
+port: 15432
+database: postgres
+user: postgres
+password: test

--- a/ci/travis_mysql.yml
+++ b/ci/travis_mysql.yml
@@ -1,6 +1,0 @@
-type: mysql
-host: localhost
-port: 3306
-database: travis_ci_test
-user: travis
-password: ""

--- a/ci/travis_postgresql.yml
+++ b/ci/travis_postgresql.yml
@@ -1,6 +1,0 @@
-type: postgresql
-host: localhost
-port: 5432
-database: travis_ci_test
-user: postgres
-password: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,25 @@
+version: '3.1'
+services:
+  mysql:
+    container_name: embulk-input-mysql-server
+    image: mysql:5.6.42
+    ports:
+      - 13306:3306
+    tmpfs:
+      - /var/lib/mysql
+    environment:
+      MYSQL_DATABASE: ci_test
+      MYSQL_ROOT_PASSWORD: root
+      MYSQL_USER: test
+      MYSQL_PASSWORD: test
+
+  postgresql:
+    container_name: embulk-input-postgresql-server
+    image: postgres:9.4.20
+    ports:
+      - 15432:5432
+    environment:
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: test
+    tmpfs:
+      - /var/lib/postgresql/data

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -191,10 +191,22 @@ in:
 $ ./gradlew gem
 ```
 
-Running tests:
+## Run tests:
 
 ```
-$ cp ci/travis_mysql.yml ci/mysql.yml  # edit this file if necessary
+$ vi ci/mysql.yml  # edit this file if necessary
+
+$ docker-compose up -d
+Creating network "embulk-input-jdbc_default" with the default driver
+Creating embulk-input-postgresql-server ... done
+Creating embulk-input-mysql-server      ... done
+
+$ docker-compose ps
+             Name                           Command              State            Ports
+------------------------------------------------------------------------------------------------
+embulk-input-mysql-server        docker-entrypoint.sh mysqld     Up      0.0.0.0:13306->3306/tcp
+embulk-input-postgresql-server   docker-entrypoint.sh postgres   Up      0.0.0.0:15432->5432/tcp
+
 $ EMBULK_INPUT_MYSQL_TEST_CONFIG=`pwd`/ci/mysql.yml ./gradlew :embulk-input-mysql:check --info
 ```
 

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -213,10 +213,22 @@ in:
 $ ./gradlew gem
 ```
 
-Running tests:
+## Run tests:
 
 ```
-$ cp ci/travis_postgresql.yml ci/postgresql.yml  # edit this file if necessary
+$ vi ci/postgresql.yml  # edit this file if necessary
+
+$ docker-compose up -d
+Creating network "embulk-input-jdbc_default" with the default driver
+Creating embulk-input-postgresql-server ... done
+Creating embulk-input-mysql-server      ... done
+
+$ docker-compose ps
+             Name                           Command              State            Ports
+------------------------------------------------------------------------------------------------
+embulk-input-mysql-server        docker-entrypoint.sh mysqld     Up      0.0.0.0:13306->3306/tcp
+embulk-input-postgresql-server   docker-entrypoint.sh postgres   Up      0.0.0.0:15432->5432/tcp
+
 $ EMBULK_INPUT_POSTGRESQL_TEST_CONFIG=`pwd`/ci/postgresql.yml ./gradlew :embulk-input-postgresql:check --info
 ```
 

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLTests.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLTests.java
@@ -23,6 +23,7 @@ public class PostgreSQLTests
         pb.environment().put("PGUSER", config.get(String.class, "user"));
         pb.environment().put("PGPASSWORD", config.get(String.class, "password"));
         pb.environment().put("PGDATABASE", config.get(String.class, "database"));
+        pb.environment().put("PGHOST", config.get(String.class, "host", "localhost"));
         pb.environment().put("PGPORT", config.get(String.class, "port", "5432"));
         pb.redirectErrorStream(true);
         int code;


### PR DESCRIPTION
This PR makes running MySQL/PostgreSQL unit tests execution much easier at local environment.
Currently, we have to build local MySQL/PostgreSQL server at our local environment.
This force developer to spend a lot of time especially for new contributors.

With this PR, we just need following process to build local MySQL and PostgreSQL server.
* Install [Docker](https://www.docker.com/get-started) on our machine (Docker is provided for Linux, Mac and Windows)
* Exec `docker compose up -d` command

We can also use existing local/external MySQL/PostgreSQL server as before if we want .

I also considered to use Docker for MSSQL and Oracle tests.
However, those Docker image have complex process to build container and I'm not aware about license of them.
Then, that should be a next step.