### PR TITLE
Fix CI failure on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
 services:
   - postgresql
 jdk:
-  - oraclejdk8
+  - openjdk8
 env:
   global:
     - _JAVA_OPTIONS="-Xmx2048m -Xms512m"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 language: java
-dist: trusty
+dist: xernial
 sudo: required
 addons:
   postgresql: "9.4"
   apt:
     sources:
-      - mysql-5.7-trusty
+      - mysql-5.7-xenial
     packages:
       - mysql-server
       - mysql-client

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ cache:
   directories:  # run "travis cache --delete" to delete caches
     - $HOME/.gradle
 before_install:
+  - sudo service mysql start
   - sudo mysql -e "use mysql; update user set plugin='mysql_native_password';FLUSH PRIVILEGES;"
   - sudo mysql_upgrade -u root
   - sudo service mysql restart


### PR DESCRIPTION
Let me take a look again tomorrow.

-----------------------------------
Currently, Travis CI jobs are failing.
https://travis-ci.org/embulk/embulk-input-jdbc/builds/563396570

This PR will fix this failure.

```
The following packages have unmet dependencies:
 mysql-client : Depends: mysql-client-5.5 but it is not going to be installed
 mysql-server : Depends: mysql-server-5.5 but it is not going to be installed
E: Unable to correct problems, you have held broken packages.
apt-get.diagnostics
apt-get install failed
...
Reading package lists...
W: http://ppa.launchpad.net/couchdb/stable/ubuntu/dists/trusty/Release.gpg: Signature by key 15866BAFD9BCC4F3C1E0DFC7D69548E1C17EAB57 uses weak digest algorithm (SHA1)
W: GPG error: https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 6B05F25D762E3157
W: The repository 'https://packagecloud.io/github/git-lfs/ubuntu trusty InRelease' is not signed.
W: There is no public key available for the following key IDs:
6B05F25D762E3157  
The command "sudo -E apt-get -yq --no-install-suggests --no-install-recommends $(travis_apt_get_options) install mysql-server mysql-client" failed and exited with 100 during .
```

I think there're 3 reasons.

* Support for Ubuntu trusty ended and MySQL 5.7 (server|client) packages are no longer provided for Ubuntu trusty
  https://travis-ci.community/t/cant-install-mysql-5-7-on-ubuntu-trusty/4311/4
  https://forums.mysql.com/read.php?11,677237,677268#msg-677268
  I upgraded to "xernial". Unfortunately, JDK install failed with a more newer version "bionic".
* Oracle JDK ask us to agree with the license during CI process
  ```
   The command "~/bin/install-jdk.sh --target "/home/travis/oraclejdk8" --workspace "/home/travis/.cache/install-jdk" --feature "8" --license "BCL"" failed and exited with 3 during 
  ```
  https://travis-ci.org/embulk/embulk-input-jdbc/builds/563526294
* Need to update mysql password reset procedure

As a short term solution, this PR would work.
As a long term solution, I propose to migrate to Docker-based test/CI env https://github.com/embulk/embulk-input-jdbc/pull/154
The Docker-based test/CI env would benefit not only for a CI environment but also for OSS contributors. This also needs to update some parts and solve a conflict, though.