### PR TITLE
Support socket_timeout for Microsoft SQL Server JDBC Driver

### DIFF
--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -194,6 +194,7 @@ public class SQLServerInputPlugin
         else {
             // SQLServerDriver properties
             props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
+            props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout() * 1000L)); // milliseconds
 
             props.setProperty("applicationName", sqlServerTask.getApplicationName());
 


### PR DESCRIPTION
embulk-input-sqlserver supported socket_timeout only for jTDS driver.