### PR TITLE
Fix typo of Ubuntu distribution name in .travis.yml to fix CI failure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: java
-dist: xernial
+dist: xenial
 sudo: required
 addons:
   postgresql: "9.4"


### PR DESCRIPTION
s/xernial/xenial to fix Travis CI failure
https://travis-ci.org/embulk/embulk-input-jdbc/builds/577710116