### PR TITLE
Update ssl option doc README

### DIFF
--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -39,7 +39,7 @@ MySQL input plugin for Embulk loads records from MySQL.
     - Internally, `useCursorFetch=false` is used and `java.sql.Statement.setFetchSize` is not set.
 - **connect_timeout**: timeout for socket connect. 0 means no timeout. (integer (seconds), default: 300)
 - **socket_timeout**: timeout on network socket operations. 0 means no timeout. (integer (seconds), default: 1800)
-- **ssl**: use SSL to connect to the database (string, default: `disable`. `enable` uses SSL without server-side validation and `verify` checks the certificate. For compatibility reasons, `true` behaves as `enable` and `false` behaves as `disable`.)
+- **ssl**: use SSL to connect to the database (string, default: `disable`. `enable` uses SSL without server-side validation nor verify checks the certificate. For compatibility reasons, `true` behaves as `enable` and `false` behaves as `disable`.)
 - **options**: extra JDBC properties (hash, default: {})
 - **incremental**: if true, enables incremental loading. See next section for details (boolean, default: false)
 - **incremental_columns**: column names for incremental loading (array of strings, default: use primary keys). Columns of integer types, string types, `datetime` and `timestamp` are supported.


### PR DESCRIPTION
@hito4t
follow-up for https://github.com/embulk/embulk-input-jdbc/pull/172

About the current readme of embulk-input-mysql.
In the case of `ssl: true` option. It results with this parameters.
```
jdbc:mysql://***:3306/*** options {useCompression=true, socketTimeout=1800000, useSSL=true, user=***, useLegacyDatetimeCode=false, requireSSL=true, tcpKeepAlive=true, verifyServerCertificate=false, useCursorFetch=true, connectTimeout=300000, password=***, zeroDateTimeBehavior=convertToNull}
```
From this part of readme, I recommend to use "nor" instead of "and". It can reduce miss-reading.
So, I''ll open this ticket.
```
**ssl**: use SSL to connect to the database (string, default: `disable`. `enable` uses SSL without server-side validation and `verify` checks the certificate.
```

current
![image](https://user-images.githubusercontent.com/1734549/72494667-f3b90f80-3867-11ea-8666-023fa3b19f3e.png)

proposal to change
![image](https://user-images.githubusercontent.com/1734549/72494697-09c6d000-3868-11ea-8ca9-421af082fab8.png)
