### PR TITLE
Replace Exec.getLogger with LoggerFactory.getLogger

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -16,6 +16,7 @@ import java.sql.SQLException;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Optional;
@@ -52,7 +53,7 @@ import static java.util.Locale.ENGLISH;
 public abstract class AbstractJdbcInputPlugin
         implements InputPlugin
 {
-    protected final Logger logger = Exec.getLogger(getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     public interface PluginTask extends Task
     {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -13,9 +13,9 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
 
-import org.embulk.spi.Exec;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.ArrayList;
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableSet;
 public class JdbcInputConnection
         implements AutoCloseable
 {
-    protected final Logger logger = Exec.getLogger(getClass());
+    protected final Logger logger = LoggerFactory.getLogger(getClass());
 
     protected final Connection connection;
     protected final String schemaName;

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
@@ -6,7 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.slf4j.Logger;
-import org.embulk.spi.Exec;
+import org.slf4j.LoggerFactory;
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.JdbcLiteral;
 import org.embulk.input.jdbc.getter.ColumnGetter;
@@ -14,7 +14,7 @@ import org.embulk.input.jdbc.getter.ColumnGetter;
 public class PostgreSQLInputConnection
         extends JdbcInputConnection
 {
-    private final Logger logger = Exec.getLogger(PostgreSQLInputConnection.class);
+    private final Logger logger = LoggerFactory.getLogger(PostgreSQLInputConnection.class);
 
     public PostgreSQLInputConnection(Connection connection, String schemaName)
             throws SQLException


### PR DESCRIPTION
`Exec.getLogger` is now deprecated in Embulk. Plugins can call `LoggerFactory.getLogger` directly.