### PR TITLE
Replace Guava Optional to java.util.Optional

### DIFF
--- a/embulk-input-db2/src/main/java/org/embulk/input/DB2InputPlugin.java
+++ b/embulk-input-db2/src/main/java/org/embulk/input/DB2InputPlugin.java
@@ -3,6 +3,7 @@ package org.embulk.input;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.Properties;
 
 import org.embulk.config.Config;
@@ -11,7 +12,6 @@ import org.embulk.input.db2.DB2InputConnection;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
 
-import com.google.common.base.Optional;
 import static java.util.Locale.ENGLISH;
 
 public class DB2InputPlugin
@@ -82,7 +82,7 @@ public class DB2InputPlugin
 
         Connection con = DriverManager.getConnection(url, props);
         try {
-            DB2InputConnection c = new DB2InputConnection(con, db2Task.getSchema().orNull());
+            DB2InputConnection c = new DB2InputConnection(con, db2Task.getSchema().orElse(null));
             con = null;
             return c;
         } finally {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
@@ -2,11 +2,11 @@ package org.embulk.input;
 
 import java.util.Set;
 import java.util.HashSet;
+import java.util.Optional;
 import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -87,7 +87,7 @@ public class JdbcInputPlugin
 
         Connection con = driver.connect(t.getUrl(), props);
         try {
-            JdbcInputConnection c = new JdbcInputConnection(con, t.getSchema().orNull());
+            JdbcInputConnection c = new JdbcInputConnection(con, t.getSchema().orElse(null));
             con = null;
             return c;
         } finally {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -13,14 +13,13 @@ import java.util.Properties;
 import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Optional;
-import com.google.common.base.Supplier;
 import com.google.common.base.Throwables;
 import com.google.common.collect.ImmutableList;
 
@@ -570,18 +569,14 @@ public abstract class AbstractJdbcInputPlugin
             }
         }
 
-        return Optional
-                .fromNullable(columnOption)
-                .or(Optional.fromNullable(defaultColumnOptions.get(targetColumnSQLType)))
-                .or(
-                    // default column option
-                    new Supplier<JdbcColumnOption>()
-                    {
-                        public JdbcColumnOption get()
-                        {
-                            return Exec.newConfigSource().loadConfig(JdbcColumnOption.class);
-                        }
-                    });
+        if (columnOption != null) {
+            return columnOption;
+        }
+        final JdbcColumnOption defaultColumnOption = defaultColumnOptions.get(targetColumnSQLType);
+        if (defaultColumnOption != null) {
+            return defaultColumnOption;
+        }
+        return Exec.newConfigSource().loadConfig(JdbcColumnOption.class);
     }
 
     private long fetch(BatchSelect cursor,

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -1,5 +1,6 @@
 package org.embulk.input.jdbc;
 
+import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigInject;
@@ -7,8 +8,6 @@ import org.embulk.config.Task;
 import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
 import org.joda.time.DateTimeZone;
-
-import com.google.common.base.Optional;
 
 public interface JdbcColumnOption
         extends Task

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -19,12 +19,12 @@ import org.slf4j.LoggerFactory;
 
 import java.util.List;
 import java.util.ArrayList;
+import java.util.Optional;
 import java.util.TreeMap;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 
@@ -237,7 +237,7 @@ public class JdbcInputConnection
         StringBuilder sb = new StringBuilder();
 
         sb.append("SELECT ");
-        sb.append(selectExpression.or("*"));
+        sb.append(selectExpression.orElse("*"));
         sb.append(" FROM ").append(buildTableName(tableName));
 
         if (whereCondition.isPresent()) {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcSchema.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcSchema.java
@@ -1,7 +1,7 @@
 package org.embulk.input.jdbc;
 
 import java.util.List;
-import com.google.common.base.Optional;
+import java.util.Optional;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
@@ -50,6 +50,6 @@ public class JdbcSchema
                 return Optional.of(i);
             }
         }
-        return Optional.absent();
+        return Optional.empty();
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToString.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToString.java
@@ -1,11 +1,11 @@
 package org.embulk.input.jdbc;
 
-import com.google.common.base.Optional;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Optional;
 
 public class ToString
 {
@@ -19,7 +19,7 @@ public class ToString
     @JsonCreator
     ToString(Optional<JsonNode> option) throws JsonMappingException
     {
-        JsonNode node = option.or(NullNode.getInstance());
+        JsonNode node = option.orElse(NullNode.getInstance());
         if (node.isTextual()) {
             this.string = node.textValue();
         } else if (node.isValueNode()) {

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -6,8 +6,8 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
-import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 
 import org.embulk.config.Config;

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -1,6 +1,6 @@
 package org.embulk.input.mysql;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.config.TaskSource;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -32,19 +32,19 @@ public class MySQLColumnGetterFactoryTest
             @Override
             public Optional<Type> getType()
             {
-                return Optional.absent();
+                return Optional.empty();
             }
 
             @Override
             public Optional<TimestampFormat> getTimestampFormat()
             {
-                return Optional.absent();
+                return Optional.empty();
             }
 
             @Override
             public Optional<DateTimeZone> getTimeZone()
             {
-                return Optional.absent();
+                return Optional.empty();
             }
 
             @Override

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -1,6 +1,6 @@
 package org.embulk.input;
 
-import com.google.common.base.Optional;
+import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -124,7 +124,7 @@ public class OracleInputPlugin
 
         Connection con = DriverManager.getConnection(url, props);
         try {
-            OracleInputConnection c = new OracleInputConnection(con, oracleTask.getSchema().orNull());
+            OracleInputConnection c = new OracleInputConnection(con, oracleTask.getSchema().orElse(null));
             con = null;
             return c;
         } finally {

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.Optional;
 
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
@@ -13,8 +14,6 @@ import org.embulk.input.postgresql.PostgreSQLInputConnection;
 import org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
 import org.joda.time.DateTimeZone;
-
-import com.google.common.base.Optional;
 
 public class PostgreSQLInputPlugin
         extends AbstractJdbcInputPlugin

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -4,6 +4,7 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 import java.util.Properties;
+import java.util.Optional;
 import javax.validation.constraints.Size;
 
 import org.embulk.config.Config;
@@ -14,7 +15,6 @@ import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.sqlserver.SQLServerInputConnection;
 
-import com.google.common.base.Optional;
 import org.embulk.input.sqlserver.getter.SQLServerColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
 import org.joda.time.DateTimeZone;
@@ -151,8 +151,8 @@ public class SQLServerInputPlugin
         if (driver != null) {
             Connection con = driver.connect(urlAndProps.getUrl(), props);
             try {
-                SQLServerInputConnection c = new SQLServerInputConnection(con, sqlServerTask.getSchema().orNull(),
-                        sqlServerTask.getTransactionIsolationLevel().orNull());
+                SQLServerInputConnection c = new SQLServerInputConnection(con, sqlServerTask.getSchema().orElse(null),
+                        sqlServerTask.getTransactionIsolationLevel().orElse(null));
                 con = null;
                 return c;
             }


### PR DESCRIPTION
Embulk is going to deprecate Guava usage, especially about Guava `Optional` in Configs and Tasks. We're replacing them with Java 8's `java.util.Optional`.