### PR TITLE
Replace Joda-Time DateTimeZone to Java 8 java.time classes

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -45,7 +45,6 @@ import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.jdbc.JdbcInputConnection.BatchSelect;
 import org.embulk.input.jdbc.JdbcInputConnection.PreparedQuery;
-import org.joda.time.DateTimeZone;
 
 import static java.util.Locale.ENGLISH;
 
@@ -145,7 +144,7 @@ public abstract class AbstractJdbcInputPlugin
 
         @Config("default_timezone")
         @ConfigDefault("\"UTC\"")
-        public DateTimeZone getDefaultTimeZone();
+        public String getDefaultTimeZone();
 
         @Config("default_column_options")
         @ConfigDefault("{}")
@@ -535,7 +534,7 @@ public abstract class AbstractJdbcInputPlugin
         return report;
     }
 
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, String dateTimeZone)
     {
         return new ColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -7,7 +7,6 @@ import org.embulk.config.ConfigInject;
 import org.embulk.config.Task;
 import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
-import org.joda.time.DateTimeZone;
 
 public interface JdbcColumnOption
         extends Task
@@ -26,5 +25,5 @@ public interface JdbcColumnOption
 
     @Config("timezone")
     @ConfigDefault("null")
-    public Optional<DateTimeZone> getTimeZone();
+    public Optional<String> getTimeZone();
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -18,17 +18,16 @@ import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
-import org.joda.time.DateTimeZone;
 
 import static java.util.Locale.ENGLISH;
 
 public class ColumnGetterFactory
 {
     protected final PageBuilder to;
-    private final DateTimeZone defaultTimeZone;
+    private final String defaultTimeZone;
     private final Map<Integer, String> jdbcTypes = getAllJDBCTypes();
 
-    public ColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    public ColumnGetterFactory(PageBuilder to, String defaultTimeZone)
     {
         this.to = to;
         this.defaultTimeZone = defaultTimeZone;

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -18,7 +18,6 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.mysql.MySQLInputConnection;
 import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class MySQLInputPlugin
         extends AbstractJdbcInputPlugin
@@ -136,7 +135,7 @@ public class MySQLInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
     {
         return new MySQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
@@ -9,22 +9,22 @@ import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
 import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampParser;
-import org.joda.time.DateTimeZone;
 
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.ZoneId;
 import java.util.Optional;
 
 public abstract class AbstractMySQLTimestampIncrementalHandler
         extends AbstractIncrementalHandler
 {
-    protected final DateTimeZone sessionTimeZone;
+    protected final ZoneId sessionTimeZone;
     protected long epochSecond;
     protected int nano;
 
-    public AbstractMySQLTimestampIncrementalHandler(DateTimeZone sessionTimeZone, ColumnGetter next)
+    public AbstractMySQLTimestampIncrementalHandler(final ZoneId sessionTimeZone, final ColumnGetter next)
     {
         super(next);
         this.sessionTimeZone = sessionTimeZone;

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -47,8 +47,7 @@ public class MySQLColumnGetterFactory
             }
 
             TimeZone timeZone = mysqlInputConnection.getServerTimezoneTZ();
-            // Joda-Time's timezone mapping is probably not compatible with java.util.TimeZone if null is returned.
-            final ZoneId sessionTimeZone = checkNotNull(timeZone.toZoneId());
+            final ZoneId sessionTimeZone = timeZone.toZoneId();
             if (column.getTypeName().equals("DATETIME")) {
                 return new MySQLDateTimeTimestampIncrementalHandler(sessionTimeZone, getter);
             }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -11,8 +11,8 @@ import org.embulk.input.jdbc.getter.JsonColumnGetter;
 import org.embulk.input.mysql.MySQLInputConnection;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Types;
-import org.joda.time.DateTimeZone;
 
+import java.time.ZoneId;
 import java.util.TimeZone;
 
 import static com.google.common.base.Preconditions.checkNotNull;
@@ -20,7 +20,7 @@ import static com.google.common.base.Preconditions.checkNotNull;
 public class MySQLColumnGetterFactory
         extends ColumnGetterFactory
 {
-    public MySQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    public MySQLColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }
@@ -48,7 +48,7 @@ public class MySQLColumnGetterFactory
 
             TimeZone timeZone = mysqlInputConnection.getServerTimezoneTZ();
             // Joda-Time's timezone mapping is probably not compatible with java.util.TimeZone if null is returned.
-            DateTimeZone sessionTimeZone = checkNotNull(DateTimeZone.forTimeZone(timeZone));
+            final ZoneId sessionTimeZone = checkNotNull(timeZone.toZoneId());
             if (column.getTypeName().equals("DATETIME")) {
                 return new MySQLDateTimeTimestampIncrementalHandler(sessionTimeZone, getter);
             }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLDateTimeTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLDateTimeTimestampIncrementalHandler.java
@@ -1,14 +1,17 @@
 package org.embulk.input.mysql.getter;
 
 import org.embulk.input.jdbc.getter.ColumnGetter;
-import org.joda.time.DateTimeZone;
 
 import java.sql.Timestamp;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 public class MySQLDateTimeTimestampIncrementalHandler
         extends AbstractMySQLTimestampIncrementalHandler
 {
-    public MySQLDateTimeTimestampIncrementalHandler(DateTimeZone sessionTimeZone, ColumnGetter next)
+    public MySQLDateTimeTimestampIncrementalHandler(final ZoneId sessionTimeZone, final ColumnGetter next)
     {
         super(sessionTimeZone, next);
     }
@@ -23,7 +26,8 @@ public class MySQLDateTimeTimestampIncrementalHandler
     public org.embulk.spi.time.Timestamp utcTimestampFromSessionTime(long epochSecond, int nano)
     {
         // this Timestamp value is already converted by session time_zone.
-        long reconverted = sessionTimeZone.convertUTCToLocal(epochSecond * 1000) / 1000; // reconvert from session time_zone to UTC
+        final long reconverted = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond), this.sessionTimeZone).
+                withZoneSameLocal(ZoneOffset.UTC).toEpochSecond();  // reconvert from session time_zone to UTC
         return org.embulk.spi.time.Timestamp.ofEpochSecond(reconverted, nano);
     }
 
@@ -37,7 +41,8 @@ public class MySQLDateTimeTimestampIncrementalHandler
     public Timestamp utcTimestampToSessionTime(org.embulk.spi.time.Timestamp from)
     {
         // reconvert from UTC to session time_zone
-        long reconverted = sessionTimeZone.convertLocalToUTC(from.getEpochSecond() * 1000, false);
+        final long reconverted = ZonedDateTime.ofInstant(Instant.ofEpochSecond(from.getEpochSecond()), ZoneOffset.UTC)
+                .withZoneSameLocal(this.sessionTimeZone).toEpochSecond() * 1000;
         Timestamp sqlTimestamp = new Timestamp(reconverted);
         sqlTimestamp.setNanos(from.getNano());
         return sqlTimestamp;

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLTimestampTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLTimestampTimestampIncrementalHandler.java
@@ -1,14 +1,14 @@
 package org.embulk.input.mysql.getter;
 
 import org.embulk.input.jdbc.getter.ColumnGetter;
-import org.joda.time.DateTimeZone;
 
 import java.sql.Timestamp;
+import java.time.ZoneId;
 
 public class MySQLTimestampTimestampIncrementalHandler
         extends AbstractMySQLTimestampIncrementalHandler
 {
-    public MySQLTimestampTimestampIncrementalHandler(DateTimeZone sessionTimeZone, ColumnGetter next)
+    public MySQLTimestampTimestampIncrementalHandler(final ZoneId sessionTimeZone, final ColumnGetter next)
     {
         super(sessionTimeZone, next);
     }

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -10,7 +10,6 @@ import org.embulk.input.jdbc.getter.StringColumnGetter;
 import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
 import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
-import org.joda.time.DateTimeZone;
 import org.junit.Test;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -42,7 +41,7 @@ public class MySQLColumnGetterFactoryTest
             }
 
             @Override
-            public Optional<DateTimeZone> getTimeZone()
+            public Optional<String> getTimeZone()
             {
                 return Optional.empty();
             }

--- a/embulk-input-mysql/src/test/resources/org/embulk/input/mysql/test/expect/basic/test_invalid_zone_config.yml
+++ b/embulk-input-mysql/src/test/resources/org/embulk/input/mysql/test/expect/basic/test_invalid_zone_config.yml
@@ -1,0 +1,8 @@
+table: test1
+order_by: 'id'
+column_options:
+  c11: {type: string, timestamp_format: '%Y/%m/%d'}
+  c12: {type: string, timestamp_format: '%Y/%m/%d %H:%M:%S'}
+  c13: {type: string, timestamp_format: '%Y/%m/%d %H:%M:%S', timezone: 'Somewhere/Some_City'}
+  c14: {type: string, timestamp_format: '%H-%M-%S', timezone: 'UTC'}
+  c15: {type: string, timestamp_format: '%Y/%m/%d %H:%M:%S.%6N'}

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -9,7 +9,6 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.oracle.OracleInputConnection;
 import org.embulk.input.oracle.getter.OracleColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
@@ -135,7 +134,7 @@ public class OracleInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone) {
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone) {
         return new OracleColumnGetterFactory(pageBuilder, dateTimeZone);
     }
 

--- a/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java
@@ -8,12 +8,11 @@ import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.jdbc.getter.TimestampWithoutTimeZoneIncrementalHandler;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class OracleColumnGetterFactory extends ColumnGetterFactory
 {
 
-  public OracleColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone) {
+  public OracleColumnGetterFactory(final PageBuilder to, final String defaultTimeZone) {
     super(to, defaultTimeZone);
   }
 

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -13,7 +13,6 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
 import org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class PostgreSQLInputPlugin
         extends AbstractJdbcInputPlugin
@@ -107,7 +106,7 @@ public class PostgreSQLInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
     {
         return new PostgreSQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -11,11 +11,10 @@ import org.embulk.input.jdbc.getter.TimestampWithTimeZoneIncrementalHandler;
 import org.embulk.input.jdbc.getter.TimestampWithoutTimeZoneIncrementalHandler;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Types;
-import org.joda.time.DateTimeZone;
 
 public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
 {
-    public PostgreSQLColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    public PostgreSQLColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }

--- a/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
@@ -13,7 +13,6 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
 import org.embulk.input.redshift.getter.RedshiftColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class RedshiftInputPlugin
         extends AbstractJdbcInputPlugin
@@ -97,7 +96,7 @@ public class RedshiftInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
     {
         return new RedshiftColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java
@@ -9,11 +9,10 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.jdbc.getter.TimestampWithTimeZoneIncrementalHandler;
 import org.embulk.input.jdbc.getter.TimestampWithoutTimeZoneIncrementalHandler;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class RedshiftColumnGetterFactory extends ColumnGetterFactory
 {
-    public RedshiftColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    public RedshiftColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -17,7 +17,6 @@ import org.embulk.input.sqlserver.SQLServerInputConnection;
 
 import org.embulk.input.sqlserver.getter.SQLServerColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 import static java.util.Locale.ENGLISH;
 
@@ -166,7 +165,7 @@ public class SQLServerInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(PageBuilder pageBuilder, DateTimeZone dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
     {
         return new SQLServerColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
@@ -6,11 +6,10 @@ import org.embulk.input.jdbc.JdbcColumnOption;
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.*;
 import org.embulk.spi.PageBuilder;
-import org.joda.time.DateTimeZone;
 
 public class SQLServerColumnGetterFactory extends ColumnGetterFactory {
 
-    public SQLServerColumnGetterFactory(PageBuilder to, DateTimeZone defaultTimeZone)
+    public SQLServerColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }


### PR DESCRIPTION
Along with making JRuby optional in Embulk, Joda-Time would be also deprecated. Java 8's `java.time` classes can replace them.