### PR TITLE
Replace Embulk's Timestamp-related classes to embulk-util-timestamp and java.time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ subprojects {
 
     dependencies {
         compileOnly "org.embulk:embulk-core:0.9.23"
+        compile "org.embulk:embulk-util-timestamp:0.2.0"
 
         testCompile "org.embulk:embulk-core:0.9.23"
         testCompile "org.embulk:embulk-test:0.9.23"

--- a/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -3,9 +3,7 @@ package org.embulk.input.jdbc;
 import java.util.Optional;
 import org.embulk.config.Config;
 import org.embulk.config.ConfigDefault;
-import org.embulk.config.ConfigInject;
 import org.embulk.config.Task;
-import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
 
 public interface JdbcColumnOption
@@ -21,7 +19,7 @@ public interface JdbcColumnOption
 
     @Config("timestamp_format")
     @ConfigDefault("null")
-    public Optional<TimestampFormat> getTimestampFormat();
+    public Optional<String> getTimestampFormat();
 
     @Config("timezone")
     @ConfigDefault("null")

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractTimestampColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractTimestampColumnGetter.java
@@ -1,8 +1,8 @@
 package org.embulk.input.jdbc.getter;
 
+import java.time.Instant;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.embulk.util.timestamp.TimestampFormatter;
 
@@ -10,7 +10,7 @@ public abstract class AbstractTimestampColumnGetter
         extends AbstractColumnGetter
 {
     protected final TimestampFormatter timestampFormatter;
-    protected Timestamp value;
+    protected Instant value;
 
     public AbstractTimestampColumnGetter(PageBuilder to, Type toType, TimestampFormatter timestampFormatter)
     {
@@ -22,7 +22,7 @@ public abstract class AbstractTimestampColumnGetter
     @Override
     public void stringColumn(Column column)
     {
-        to.setString(column, timestampFormatter.format(value.getInstant()));
+        to.setString(column, timestampFormatter.format(value));
     }
 
     @Override
@@ -33,6 +33,6 @@ public abstract class AbstractTimestampColumnGetter
     @Override
     public void timestampColumn(Column column)
     {
-        to.setTimestamp(column, value);
+        to.setTimestamp(column, org.embulk.spi.time.Timestamp.ofInstant(value));
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractTimestampColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractTimestampColumnGetter.java
@@ -3,8 +3,8 @@ package org.embulk.input.jdbc.getter;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public abstract class AbstractTimestampColumnGetter
         extends AbstractColumnGetter
@@ -22,7 +22,7 @@ public abstract class AbstractTimestampColumnGetter
     @Override
     public void stringColumn(Column column)
     {
-        to.setString(column, timestampFormatter.format(value));
+        to.setString(column, timestampFormatter.format(value.getInstant()));
     }
 
     @Override

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
@@ -5,9 +5,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class DateColumnGetter
         extends AbstractTimestampColumnGetter

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DateColumnGetter.java
@@ -3,8 +3,8 @@ package org.embulk.input.jdbc.getter;
 import java.sql.Date;
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 import org.embulk.util.timestamp.TimestampFormatter;
@@ -24,7 +24,7 @@ public class DateColumnGetter
     {
         Date date = from.getDate(fromIndex);
         if (date != null) {
-            value = Timestamp.ofEpochMilli(date.getTime());
+            value = Instant.ofEpochMilli(date.getTime());
         }
     }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimeColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimeColumnGetter.java
@@ -3,8 +3,8 @@ package org.embulk.input.jdbc.getter;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Time;
+import java.time.Instant;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 import org.embulk.util.timestamp.TimestampFormatter;
@@ -24,7 +24,7 @@ public class TimeColumnGetter
     {
         Time time = from.getTime(fromIndex);
         if (time != null) {
-            value = Timestamp.ofEpochMilli(time.getTime());
+            value = Instant.ofEpochMilli(time.getTime());
         }
     }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimeColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimeColumnGetter.java
@@ -5,9 +5,9 @@ import java.sql.SQLException;
 import java.sql.Time;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimeColumnGetter
         extends AbstractTimestampColumnGetter

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
@@ -2,8 +2,8 @@ package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
+import java.time.Instant;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.time.Timestamp;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
 import org.embulk.util.timestamp.TimestampFormatter;
@@ -23,7 +23,7 @@ public class TimestampColumnGetter
     {
         java.sql.Timestamp timestamp = from.getTimestamp(fromIndex);
         if (timestamp != null) {
-            value = Timestamp.ofEpochSecond(timestamp.getTime() / 1000, timestamp.getNanos());
+            value = Instant.ofEpochSecond(timestamp.getTime() / 1000, timestamp.getNanos());
         }
     }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
@@ -4,9 +4,9 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.time.Timestamp;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimestampColumnGetter
         extends AbstractTimestampColumnGetter

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampColumnGetter.java
@@ -2,7 +2,6 @@ package org.embulk.input.jdbc.getter;
 
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.Instant;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
@@ -23,7 +22,7 @@ public class TimestampColumnGetter
     {
         java.sql.Timestamp timestamp = from.getTimestamp(fromIndex);
         if (timestamp != null) {
-            value = Instant.ofEpochSecond(timestamp.getTime() / 1000, timestamp.getNanos());
+            value = timestamp.toInstant();
         }
     }
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
@@ -64,7 +64,7 @@ public class TimestampWithTimeZoneIncrementalHandler
     {
         try {
             final Instant epoch = PARSER.parse(fromValue.asText());
-            Timestamp sqlTimestamp = new Timestamp(epoch.getEpochSecond() * 1000L);
+            final Timestamp sqlTimestamp = Timestamp.from(epoch);
             sqlTimestamp.setNanos(epoch.getNano());
             toStatement.setTimestamp(toIndex, sqlTimestamp);
 

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
@@ -6,6 +6,7 @@ import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.util.Optional;
 
 import org.embulk.config.ConfigException;
@@ -13,14 +14,16 @@ import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
-import org.embulk.spi.time.TimestampFormatter;
 import org.embulk.spi.time.TimestampParseException;
 import org.embulk.spi.time.TimestampParser;
+import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimestampWithTimeZoneIncrementalHandler
         extends AbstractIncrementalHandler
 {
-    private static final String ISO_USEC_FORMAT = "%Y-%m-%dT%H:%M:%S.%6NZ"; // maybe "...%6N%Z", but shouldn't correct for compatibility.
+    // maybe "...%6N%Z", but shouldn't correct for compatibility.
+    private static final TimestampFormatter FORMATTER = TimestampFormatter.builderWithRuby("%Y-%m-%dT%H:%M:%S.%6NZ").build();
+
     private static final String ISO_USEC_PATTERN = "%Y-%m-%dT%H:%M:%S.%N%z";
 
     private long epochSecond;
@@ -45,9 +48,6 @@ public class TimestampWithTimeZoneIncrementalHandler
         super.getAndSet(from, fromIndex, toColumn);
     }
 
-    private static interface FormatterIntlTask extends Task, TimestampFormatter.Task {}
-    private static interface FormatterIntlColumnOption extends Task, TimestampFormatter.TimestampColumnOption {}
-
     @Override
     public JsonNode encodeToJson()
     {
@@ -56,23 +56,7 @@ public class TimestampWithTimeZoneIncrementalHandler
 
     private String format(long epochSecond, int nano)
     {
-        // TODO: Switch to a newer TimestampFormatter constructor after a reasonable interval.
-        // Traditional constructor is used here for compatibility.
-        final ConfigSource configSource = Exec.newConfigSource();
-        configSource.set("format", ISO_USEC_FORMAT);
-        configSource.set("timezone", "UTC");
-        final FormatterIntlTask task = Exec.newConfigSource().loadConfig(FormatterIntlTask.class);
-        final Optional<? extends TimestampFormatter.TimestampColumnOption> columnOption =
-                Optional.ofNullable(configSource.loadConfig(FormatterIntlColumnOption.class));
-        final TimestampFormatter formatter = TimestampFormatter.of(
-                columnOption.isPresent()
-                        ? columnOption.get().getFormat().or(task.getDefaultTimestampFormat())
-                        : task.getDefaultTimestampFormat(),
-                columnOption.isPresent()
-                        ? columnOption.get().getTimeZoneId().or(task.getDefaultTimeZoneId())
-                        : task.getDefaultTimeZoneId());
-
-        return formatter.format(org.embulk.spi.time.Timestamp.ofEpochSecond(epochSecond, nano));
+        return FORMATTER.format(Instant.ofEpochSecond(epochSecond, nano));
     }
 
     private static interface ParserIntlTask extends Task, TimestampParser.Task {}

--- a/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
@@ -47,13 +47,13 @@ public abstract class AbstractMySQLTimestampIncrementalHandler
     public JsonNode encodeToJson()
     {
         final TimestampFormatter formatter = TimestampFormatter.builder(getTimestampFormat(), true).build();
-        String text = formatter.format(utcTimestampFromSessionTime(epochSecond, nano).getInstant());
+        String text = formatter.format(utcTimestampFromSessionTime(epochSecond, nano));
         return jsonNodeFactory.textNode(text);
     }
 
     protected abstract String getTimestampFormat();
 
-    protected abstract org.embulk.spi.time.Timestamp utcTimestampFromSessionTime(long epochSecond, int nano);
+    protected abstract Instant utcTimestampFromSessionTime(long epochSecond, int nano);
 
     @Override
     public void decodeFromJsonTo(PreparedStatement toStatement, int toIndex, JsonNode fromValue)
@@ -61,10 +61,10 @@ public abstract class AbstractMySQLTimestampIncrementalHandler
     {
         final TimestampFormatter formatter = TimestampFormatter.builder(getTimestampPattern(), true).build();
         final Instant epoch = formatter.parse(fromValue.asText());
-        toStatement.setTimestamp(toIndex, utcTimestampToSessionTime(org.embulk.spi.time.Timestamp.ofInstant(epoch)));
+        toStatement.setTimestamp(toIndex, utcTimestampToSessionTime(epoch));
     }
 
     protected abstract String getTimestampPattern();
 
-    protected abstract Timestamp utcTimestampToSessionTime(org.embulk.spi.time.Timestamp ts);
+    protected abstract Timestamp utcTimestampToSessionTime(Instant ts);
 }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLDateTimeTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLDateTimeTimestampIncrementalHandler.java
@@ -23,12 +23,12 @@ public class MySQLDateTimeTimestampIncrementalHandler
     }
 
     @Override
-    public org.embulk.spi.time.Timestamp utcTimestampFromSessionTime(long epochSecond, int nano)
+    public Instant utcTimestampFromSessionTime(final long epochSecond, final int nano)
     {
         // this Timestamp value is already converted by session time_zone.
         final long reconverted = ZonedDateTime.ofInstant(Instant.ofEpochSecond(epochSecond), this.sessionTimeZone).
                 withZoneSameLocal(ZoneOffset.UTC).toEpochSecond();  // reconvert from session time_zone to UTC
-        return org.embulk.spi.time.Timestamp.ofEpochSecond(reconverted, nano);
+        return Instant.ofEpochSecond(reconverted, nano);
     }
 
     @Override
@@ -38,10 +38,10 @@ public class MySQLDateTimeTimestampIncrementalHandler
     }
 
     @Override
-    public Timestamp utcTimestampToSessionTime(org.embulk.spi.time.Timestamp from)
+    public Timestamp utcTimestampToSessionTime(final Instant from)
     {
         // reconvert from UTC to session time_zone
-        final long reconverted = ZonedDateTime.ofInstant(Instant.ofEpochSecond(from.getEpochSecond()), ZoneOffset.UTC)
+        final long reconverted = ZonedDateTime.ofInstant(from, ZoneOffset.UTC)
                 .withZoneSameLocal(this.sessionTimeZone).toEpochSecond() * 1000;
         Timestamp sqlTimestamp = new Timestamp(reconverted);
         sqlTimestamp.setNanos(from.getNano());

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLTimestampTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLTimestampTimestampIncrementalHandler.java
@@ -3,6 +3,7 @@ package org.embulk.input.mysql.getter;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 
 import java.sql.Timestamp;
+import java.time.Instant;
 import java.time.ZoneId;
 
 public class MySQLTimestampTimestampIncrementalHandler
@@ -20,9 +21,9 @@ public class MySQLTimestampTimestampIncrementalHandler
     }
 
     @Override
-    public org.embulk.spi.time.Timestamp utcTimestampFromSessionTime(long epochSecond, int nano)
+    public Instant utcTimestampFromSessionTime(final long epochSecond, final int nano)
     {
-        return org.embulk.spi.time.Timestamp.ofEpochSecond(epochSecond, nano);
+        return Instant.ofEpochSecond(epochSecond, nano);
     }
 
     @Override
@@ -32,7 +33,7 @@ public class MySQLTimestampTimestampIncrementalHandler
     }
 
     @Override
-    public Timestamp utcTimestampToSessionTime(org.embulk.spi.time.Timestamp ts)
+    public Timestamp utcTimestampToSessionTime(final Instant ts)
     {
         Timestamp sqlTimestamp = new Timestamp(ts.getEpochSecond() * 1000);
         sqlTimestamp.setNanos(ts.getNano());

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -35,7 +35,7 @@ public class MySQLColumnGetterFactoryTest
             }
 
             @Override
-            public Optional<TimestampFormat> getTimestampFormat()
+            public Optional<String> getTimestampFormat()
             {
                 return Optional.empty();
             }

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -8,7 +8,6 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.jdbc.getter.JsonColumnGetter;
 import org.embulk.input.jdbc.getter.StringColumnGetter;
 import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
-import org.embulk.spi.time.TimestampFormat;
 import org.embulk.spi.type.Type;
 import org.junit.Test;
 

--- a/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,3 +1,5 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0

--- a/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,4 +1,6 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0
 org.postgresql:postgresql:9.4-1205-jdbc41

--- a/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -3,3 +3,5 @@
 # This file is expected to be part of source control.
 com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8
 net.sourceforge.jtds:jtds:1.3.1
+org.embulk:embulk-util-rubytime:0.3.0
+org.embulk:embulk-util-timestamp:0.2.0


### PR DESCRIPTION
Embulk's core has contained `TimestampFormatter` and `TimestampParser` in it, but they caused some compatibility problems in the past.

We are going to make them deprecated, and we're providing an independent Timestamp library `embulk-util-timestamp`. It does not depend on Embulk's core, nor JRuby.
https://github.com/embulk/embulk-util-timestamp

Once a plugin uses the Timestamp library, the plugin is not affected by any Timestamp changes in Embulk's core.