### PR TITLE
Remove use of @ConfigInject by replacing with Exec.getBufferAllocator

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -27,7 +27,6 @@ import org.embulk.config.Config;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigDiff;
-import org.embulk.config.ConfigInject;
 import org.embulk.config.ConfigSource;
 import org.embulk.config.Task;
 import org.embulk.config.TaskReport;
@@ -170,9 +169,6 @@ public abstract class AbstractJdbcInputPlugin
 
         public List<Integer> getIncrementalColumnIndexes();
         public void setIncrementalColumnIndexes(List<Integer> indexes);
-
-        @ConfigInject
-        public BufferAllocator getBufferAllocator();
     }
 
     // for subclasses to add @Config
@@ -478,7 +474,7 @@ public abstract class AbstractJdbcInputPlugin
 
         PreparedQuery builtQuery = task.getBuiltQuery();
         JdbcSchema querySchema = task.getQuerySchema();
-        BufferAllocator allocator = task.getBufferAllocator();
+        BufferAllocator allocator = Exec.getBufferAllocator();
         PageBuilder pageBuilder = new PageBuilder(allocator, schema, output);
 
         long totalRows = 0;


### PR DESCRIPTION
It is not an immediate deprecation, but using `@ConfigInject` to get `BufferAllocator` is no longer recommended. We can use `Exec.getBufferAllocator` instead.