### PR TITLE
Declare a private static logger in each class

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -52,7 +52,7 @@ import static java.util.Locale.ENGLISH;
 public abstract class AbstractJdbcInputPlugin
         implements InputPlugin
 {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(AbstractJdbcInputPlugin.class);
 
     public interface PluginTask extends Task
     {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -31,7 +31,7 @@ import com.google.common.collect.ImmutableSet;
 public class JdbcInputConnection
         implements AutoCloseable
 {
-    protected final Logger logger = LoggerFactory.getLogger(getClass());
+    private static final Logger logger = LoggerFactory.getLogger(JdbcInputConnection.class);
 
     protected final Connection connection;
     protected final String schemaName;

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -18,10 +18,14 @@ import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.mysql.MySQLInputConnection;
 import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MySQLInputPlugin
         extends AbstractJdbcInputPlugin
 {
+    private static final Logger logger = LoggerFactory.getLogger(MySQLInputPlugin.class);
+
     public interface MySQLPluginTask
             extends PluginTask
     {

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -11,10 +11,14 @@ import java.util.TimeZone;
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.JdbcLiteral;
 import org.embulk.input.jdbc.getter.ColumnGetter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class MySQLInputConnection
         extends JdbcInputConnection
 {
+    private static final Logger logger = LoggerFactory.getLogger(MySQLInputConnection.class);
+
     public MySQLInputConnection(Connection connection)
             throws SQLException
     {

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
@@ -14,7 +14,7 @@ import org.embulk.input.jdbc.getter.ColumnGetter;
 public class PostgreSQLInputConnection
         extends JdbcInputConnection
 {
-    private final Logger logger = LoggerFactory.getLogger(PostgreSQLInputConnection.class);
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLInputConnection.class);
 
     public PostgreSQLInputConnection(Connection connection, String schemaName)
             throws SQLException

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -17,12 +17,15 @@ import org.embulk.input.sqlserver.SQLServerInputConnection;
 
 import org.embulk.input.sqlserver.getter.SQLServerColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static java.util.Locale.ENGLISH;
 
 public class SQLServerInputPlugin
     extends AbstractJdbcInputPlugin
 {
+    private static final Logger logger = LoggerFactory.getLogger(SQLServerInputPlugin.class);
     private static int DEFAULT_PORT = 1433;
 
     public interface SQLServerPluginTask


### PR DESCRIPTION
As discussed in https://github.com/embulk/embulk-input-jdbc/pull/179#pullrequestreview-408056738, this PR is to have `private` `static` logger instances in each class.