### PR TITLE
Bump up to v0.12.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = 'org.embulk.input.jdbc'
-    version = "0.11.1"
+    version = "0.12.0"
     description = "Selects records from a table."
 }
 


### PR DESCRIPTION
The next version will be a big change again, then bumping up to v0.12.0, not v0.11.2.

v0.12.0 plans to :
* Catch up with the Embulk v0.10 API/SPI https://dev.embulk.org/topics/get-ready-for-v0.11-and-v1.0.html
* Validate time zone names with `embulk-util-config`'s `ZoneIdModule`
* Release JARs to Maven Central, not Bintray
* Wrap UnknownHostException to ConfigException