### PR TITLE
Update GitHub Actions to v2 to fix build fail

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -86,6 +86,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: 1.8
+        distribution: 'zulu'
     - name: Connect
       run: mysql -h 127.0.0.1 --port 3306 -uroot -proot -e "show databases;"
     - name: Create database
@@ -121,6 +122,7 @@ jobs:
     - uses: actions/setup-java@v2
       with:
         java-version: 1.8
+        distribution: 'zulu'
     - name: Connect
       run: psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -c "\l"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -85,7 +85,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
         distribution: 'zulu'
     - name: Connect
       run: mysql -h 127.0.0.1 --port 3306 -uroot -proot -e "show databases;"
@@ -121,7 +121,7 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-java@v2
       with:
-        java-version: 1.8
+        java-version: 8
         distribution: 'zulu'
     - name: Connect
       run: psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -c "\l"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
           DBNAME: testdb
           SAMPLEDB: true
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     # TODO: Find a better way to wait for completing setup.
     - name: Sleep for 5 minutes to complete all the DB2 setup process
       run: sleep 300
@@ -33,38 +33,36 @@ jobs:
       run: docker logs db2container
     - name: Show DB2 configs
       run: docker exec db2container su - db2inst1 -c "db2 \"GET DBM CFG\""
-    - name: Set env
-      run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Install ksh to run installDSDriver
       run: sudo apt-get install ksh
     - name: Make working directory
-      run: mkdir "${{ env.workspace }}/clpplus"
+      run: mkdir "${{ github.workspace }}/clpplus"
     - name: Download clpplus
       # https://github.com/rickdesantis/docker-files/tree/e3bbc10080be9e31635223c23091526bc5d9eff6/clpplus
-      run: curl "https://raw.githubusercontent.com/rickdesantis/docker-files/master/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz" -o "${{ env.workspace }}/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz"
+      run: curl "https://raw.githubusercontent.com/rickdesantis/docker-files/master/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz" -o "${{ github.workspace }}/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz"
     - name: Extract clpplus
-      run: tar zxf "${{ env.workspace }}/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz" -C "${{ env.workspace }}/clpplus"
+      run: tar zxf "${{ github.workspace }}/clpplus/ibm_data_server_driver_package_linuxx64_v10.5.tar.gz" -C "${{ github.workspace }}/clpplus"
     - name: Make installDSDriver runnable
       run: chmod +x installDSDriver
-      working-directory: "${{ env.workspace }}/clpplus/dsdriver"
+      working-directory: "${{ github.workspace }}/clpplus/dsdriver"
     - name: Run installDSDriver
       run: ./installDSDriver
-      working-directory: "${{ env.workspace }}/clpplus/dsdriver"
+      working-directory: "${{ github.workspace }}/clpplus/dsdriver"
     - name: Dump installDSDriver.log
       run: cat installDSDriver.log
-      working-directory: "${{ env.workspace }}/clpplus/dsdriver"
+      working-directory: "${{ github.workspace }}/clpplus/dsdriver"
     - name: List files
       run: ls -C -R
-      working-directory: "${{ env.workspace }}"
+      working-directory: "${{ github.workspace }}"
     - name: Run clpplus
-      run: "${{ env.workspace }}/clpplus/dsdriver/bin/clpplus -verbose 'db2inst1/password@127.0.0.1:50000/testdb' @${{ env.workspace }}/embulk-input-db2/src/test/resources/org/embulk/input/db2/test/expect/basic/setup.sql"
+      run: "${{ github.workspace }}/clpplus/dsdriver/bin/clpplus -verbose 'db2inst1/password@127.0.0.1:50000/testdb' @${{ github.workspace }}/embulk-input-db2/src/test/resources/org/embulk/input/db2/test/expect/basic/setup.sql"
     - name: Build with testing
       run: ./gradlew --stacktrace :embulk-input-db2:check
       env:
         _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
-        EMBULK_INPUT_DB2_TEST_CONFIG: "${{ env.workspace }}/ci/db2.yml"
-        EMBULK_INPUT_DB2_TEST_CLPPLUS_COMMAND: "${{ env.workspace }}/clpplus/dsdriver/bin/clpplus"
-    - uses: actions/upload-artifact@v1
+        EMBULK_INPUT_DB2_TEST_CONFIG: "${{ github.workspace }}/ci/db2.yml"
+        EMBULK_INPUT_DB2_TEST_CLPPLUS_COMMAND: "${{ github.workspace }}/clpplus/dsdriver/bin/clpplus"
+    - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: db2
@@ -84,9 +82,9 @@ jobs:
           MYSQL_USER: ci
           MYSQL_PASSWORD: password
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Set up JDK 1.8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
         java-version: 1.8
     - name: Connect
@@ -99,8 +97,8 @@ jobs:
       run: ./gradlew --stacktrace :embulk-input-mysql:check
       env:
         _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
-        EMBULK_INPUT_MYSQL_TEST_CONFIG: "${{ env.workspace }}/ci/mysql.yml"
-    - uses: actions/upload-artifact@v1
+        EMBULK_INPUT_MYSQL_TEST_CONFIG: "${{ github.workspace }}/ci/mysql.yml"
+    - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: mysql
@@ -108,7 +106,7 @@ jobs:
   oracle:  # https://hub.docker.com/_/oracle-database-enterprise-edition
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Test for Oracle Database does not run on GitHub Actions.
       run: echo "Test for Oracle Database does not run on GitHub Actions."
   postgresql:
@@ -122,7 +120,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Connect
       run: psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -c "\l"
       env:
@@ -137,8 +135,8 @@ jobs:
       run: ./gradlew --stacktrace :embulk-input-postgresql:check
       env:
         _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
-        EMBULK_INPUT_POSTGRESQL_TEST_CONFIG: "${{ env.workspace }}/ci/postgresql.yml"
-    - uses: actions/upload-artifact@v1
+        EMBULK_INPUT_POSTGRESQL_TEST_CONFIG: "${{ github.workspace }}/ci/postgresql.yml"
+    - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: postgresql
@@ -155,7 +153,7 @@ jobs:
         env:
           POSTGRES_PASSWORD: postgres
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Connect
       run: psql -h 127.0.0.1 -p 5439 -U postgres -d postgres -c "\l"
       env:
@@ -170,8 +168,8 @@ jobs:
       run: ./gradlew --stacktrace :embulk-input-redshift:check
       env:
         _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
-        EMBULK_INPUT_REDSHIFT_TEST_CONFIG: "${{ env.workspace }}/ci/redshift.yml"
-    - uses: actions/upload-artifact@v1
+        EMBULK_INPUT_REDSHIFT_TEST_CONFIG: "${{ github.workspace }}/ci/redshift.yml"
+    - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: redshift
@@ -190,7 +188,7 @@ jobs:
           ACCEPT_EULA: Y
           SA_PASSWORD: "P@ssw0rd"
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     # TODO: Find a better way to wait for completing setup.
     - name: Sleep for 30 seconds to complete all the SQL Server setup process
       run: sleep 30
@@ -201,7 +199,7 @@ jobs:
     - name: Set env
       run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Copy test resources into Docker container
-      run: docker cp ${{ env.workspace }}/embulk-input-sqlserver/src/test/resources/org/embulk/input/sqlserver/test/expect/. mssqlcontainer:/tmp
+      run: docker cp ${{ github.workspace }}/embulk-input-sqlserver/src/test/resources/org/embulk/input/sqlserver/test/expect/. mssqlcontainer:/tmp
     - name: List resource files
       run: docker exec mssqlcontainer ls -R /tmp
     - name: Show SQL Server objects
@@ -214,9 +212,9 @@ jobs:
       run: ./gradlew --stacktrace :embulk-input-sqlserver:check
       env:
         _JAVA_OPTIONS: "-Xmx2048m -Xms512m"
-        EMBULK_INPUT_SQLSERVER_TEST_CONFIG: "${{ env.workspace }}/ci/sqlserver.yml"
+        EMBULK_INPUT_SQLSERVER_TEST_CONFIG: "${{ github.workspace }}/ci/sqlserver.yml"
         EMBULK_INPUT_SQLSERVER_TEST_SQLCMD_COMMAND: "docker exec mssqlcontainer /opt/mssql-tools/bin/sqlcmd"
-    - uses: actions/upload-artifact@v1
+    - uses: actions/upload-artifact@v2
       if: always()
       with:
         name: sqlserver

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,8 +83,7 @@ jobs:
           MYSQL_PASSWORD: password
     steps:
     - uses: actions/checkout@v2
-    - name: Set up JDK 1.8
-      uses: actions/setup-java@v2
+    - uses: actions/setup-java@v2
       with:
         java-version: 1.8
     - name: Connect
@@ -119,6 +118,9 @@ jobs:
           POSTGRES_PASSWORD: postgres
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 1.8
     - name: Connect
       run: psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -c "\l"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,6 +24,10 @@ jobs:
           SAMPLEDB: true
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 8
+        distribution: 'zulu'
     # TODO: Find a better way to wait for completing setup.
     - name: Sleep for 5 minutes to complete all the DB2 setup process
       run: sleep 300
@@ -154,6 +158,10 @@ jobs:
           POSTGRES_PASSWORD: postgres
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 8
+        distribution: 'zulu'
     - name: Connect
       run: psql -h 127.0.0.1 -p 5439 -U postgres -d postgres -c "\l"
       env:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -91,8 +91,6 @@ jobs:
       run: mysql -h 127.0.0.1 --port 3306 -uroot -proot -e "show databases;"
     - name: Create database
       run: mysql -h 127.0.0.1 --port 3306 -uroot -proot -e "create database ci_test;"
-    - name: Set env
-      run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Build with testing
       run: ./gradlew --stacktrace :embulk-input-mysql:check
       env:
@@ -129,8 +127,6 @@ jobs:
       run: psql -h 127.0.0.1 -p 5432 -U postgres -d postgres -c "create database ci_test;"
       env:
         PGPASSWORD: postgres
-    - name: Set env
-      run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Build with testing
       run: ./gradlew --stacktrace :embulk-input-postgresql:check
       env:
@@ -162,8 +158,6 @@ jobs:
       run: psql -h 127.0.0.1 -p 5439 -U postgres -d postgres -c "create database ci_test;"
       env:
         PGPASSWORD: postgres
-    - name: Set env
-      run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Build with testing
       run: ./gradlew --stacktrace :embulk-input-redshift:check
       env:
@@ -196,8 +190,6 @@ jobs:
       run: docker ps -a
     - name: Confirm log
       run: docker logs mssqlcontainer
-    - name: Set env
-      run: echo ::set-env name=workspace::$GITHUB_WORKSPACE
     - name: Copy test resources into Docker container
       run: docker cp ${{ github.workspace }}/embulk-input-sqlserver/src/test/resources/org/embulk/input/sqlserver/test/expect/. mssqlcontainer:/tmp
     - name: List resource files

--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,6 @@
+import org.gradle.api.tasks.testing.logging.TestExceptionFormat
+import org.gradle.api.tasks.testing.logging.TestLogEvent
+
 plugins {
     id 'com.jfrog.bintray' version '1.8.4' apply false
     id 'java'
@@ -57,6 +60,29 @@ subprojects {
         // JDBC input plugins depend on local time zone to parse timestamp without time stamp and datetime types.
         jvmArgs "-Duser.country=FI", "-Duser.timezone=Europe/Helsinki"
         environment "TZ", "Europe/Helsinki"
+    }
+
+    tasks.withType(Test) {
+        testLogging {
+            // set options for log level LIFECYCLE
+            events TestLogEvent.FAILED,
+                    TestLogEvent.PASSED,
+                    TestLogEvent.SKIPPED,
+                    TestLogEvent.STANDARD_OUT
+            exceptionFormat TestExceptionFormat.FULL
+            showExceptions true
+            showCauses true
+            showStackTraces true
+
+            afterSuite { desc, result ->
+                if (!desc.parent) { // will match the outermost suite
+                    def output = "Results: ${result.resultType} (${result.testCount} tests, ${result.successfulTestCount} passed, ${result.failedTestCount} failed, ${result.skippedTestCount} skipped)"
+                    def startItem = '|  ', endItem = '  |'
+                    def repeatLength = startItem.length() + output.length() + endItem.length()
+                    println('\n' + ('-' * repeatLength) + '\n' + startItem + output + endItem + '\n' + ('-' * repeatLength))
+                }
+            }
+        }
     }
 
     checkstyle {


### PR DESCRIPTION
The build starts failing when `set-env` is deprecated https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/. This PR to remove `set-env` and also update some config
- Change `env.workspace` to `github.workspace`
- Update GitHub action to v2
- Add test result in build log