### PR TITLE
Catch up with Embulk API/SPI v0.10

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,13 +35,35 @@ subprojects {
     targetCompatibility = 1.8
 
     dependencies {
-        compileOnly "org.embulk:embulk-core:0.9.23"
+        compileOnly "org.embulk:embulk-api:0.10.31"
+        compileOnly "org.embulk:embulk-spi:0.10.31"
+
+        compile("org.embulk:embulk-util-config:0.3.0") {
+            // They conflict with embulk-core. They are once excluded here,
+            // and added explicitly with versions exactly the same with embulk-core:0.10.19.
+            exclude group: "com.fasterxml.jackson.core", module: "jackson-annotations"
+            exclude group: "com.fasterxml.jackson.core", module: "jackson-core"
+            exclude group: "com.fasterxml.jackson.core", module: "jackson-databind"
+            exclude group: "com.fasterxml.jackson.datatype", module: "jackson-datatype-jdk8"
+            exclude group: "javax.validation", module: "validation-api"
+        }
+
+        // They are once excluded from transitive dependencies of other dependencies,
+        // and added explicitly with versions exactly the same with embulk-core:0.10.19.
+        compile "com.fasterxml.jackson.core:jackson-annotations:2.6.7"
+        compile "com.fasterxml.jackson.core:jackson-core:2.6.7"
+        compile "com.fasterxml.jackson.core:jackson-databind:2.6.7"
+        compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
+        compile "javax.validation:validation-api:1.1.0.Final"
+
+        compile("org.embulk:embulk-util-json:0.1.0") {
+            exclude group: "org.msgpack", module: "msgpack-core"  // Included in embulk-api.
+        }
         compile "org.embulk:embulk-util-timestamp:0.2.1"
 
-        testCompile "org.embulk:embulk-core:0.9.23"
-        testCompile "org.embulk:embulk-test:0.9.23"
-        testCompile "org.embulk:embulk-deps-buffer:0.9.23"
-        testCompile "org.embulk:embulk-deps-config:0.9.23"
+        testCompile "org.embulk:embulk-junit4:0.10.31"
+        testCompile "org.embulk:embulk-core:0.10.31"
+        testCompile "org.embulk:embulk-deps:0.10.31"
     }
 
     tasks.withType(JavaCompile) {

--- a/embulk-input-db2/build.gradle
+++ b/embulk-input-db2/build.gradle
@@ -1,7 +1,11 @@
 dependencies {
     compile(project(path: ":embulk-input-jdbc", configuration: "runtimeElements"))
 
-    testCompile "org.embulk:embulk-standards:0.9.23"
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
 
     // The driver is available on Maven Central since Nov 30, 2018.
     // https://repo1.maven.org/maven2/com/ibm/db2/jcc/db2jcc/db2jcc4/

--- a/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,5 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-db2/src/main/java/org/embulk/input/DB2InputPlugin.java
+++ b/embulk-input-db2/src/main/java/org/embulk/input/DB2InputPlugin.java
@@ -6,11 +6,11 @@ import java.sql.SQLException;
 import java.util.Optional;
 import java.util.Properties;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.db2.DB2InputConnection;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 import static java.util.Locale.ENGLISH;
 

--- a/embulk-input-db2/src/test/java/org/embulk/input/db2/BasicTest.java
+++ b/embulk-input-db2/src/test/java/org/embulk/input/db2/BasicTest.java
@@ -9,8 +9,16 @@ import java.nio.file.Path;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.DB2InputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -33,6 +41,10 @@ public class BasicTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "db2", DB2InputPlugin.class)
             .build();
 

--- a/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,5 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
@@ -7,11 +7,10 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import com.google.common.base.Throwables;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 public class JdbcInputPlugin
         extends AbstractJdbcInputPlugin
@@ -81,8 +80,10 @@ public class JdbcInputPlugin
             // TODO check Class.forName(driverClass) is a Driver before newInstance
             //      for security
             driver = (Driver) Class.forName(t.getDriverClass()).newInstance();
-        } catch (Exception ex) {
-            throw Throwables.propagate(ex);
+        } catch (final RuntimeException | Error ex) {
+            throw ex;
+        } catch (final Exception ex) {
+            throw new RuntimeException(ex);
         }
 
         Connection con = driver.connect(t.getUrl(), props);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/JdbcInputPlugin.java
@@ -80,7 +80,7 @@ public class JdbcInputPlugin
             // TODO check Class.forName(driverClass) is a Driver before newInstance
             //      for security
             driver = (Driver) Class.forName(t.getDriverClass()).newInstance();
-        } catch (final RuntimeException | Error ex) {
+        } catch (final RuntimeException ex) {
             throw ex;
         } catch (final Exception ex) {
             throw new RuntimeException(ex);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -697,8 +697,8 @@ public abstract class AbstractJdbcInputPlugin
         if (!(loader instanceof URLClassLoader)) {
             throw new RuntimeException("Plugin is not loaded by URLClassLoader unexpectedly.");
         }
-        if (loader.getClass().getCanonicalName().equals("org.embulk.plugin.PluginClassLoader")) {
-            throw new RuntimeException("Plugin is not loaded by URLClassLoader unexpectedly.");
+        if (!loader.getClass().getCanonicalName().equals("org.embulk.plugin.PluginClassLoader")) {
+            throw new RuntimeException("Plugin is not loaded by PluginClassLoader unexpectedly.");
         }
         Path path = Paths.get(glob);
         if (!path.toFile().exists()) {
@@ -708,7 +708,7 @@ public abstract class AbstractJdbcInputPlugin
         try {
             addPathMethod = loader.getClass().getMethod("addPath", Path.class);
         } catch (final NoSuchMethodException ex) {
-            throw new RuntimeException("Plugin is not loaded a ClassLoader, which does not have addPath(Path) unexpectedly.");
+            throw new RuntimeException("Plugin is not loaded a ClassLoader which has addPath(Path), unexpectedly.");
         }
         try {
             addPathMethod.invoke(loader, Paths.get(glob));

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -697,7 +697,7 @@ public abstract class AbstractJdbcInputPlugin
         if (!(loader instanceof URLClassLoader)) {
             throw new RuntimeException("Plugin is not loaded by URLClassLoader unexpectedly.");
         }
-        if (!loader.getClass().getCanonicalName().equals("org.embulk.plugin.PluginClassLoader")) {
+        if (!"org.embulk.plugin.PluginClassLoader".equals(loader.getClass().getName())) {
             throw new RuntimeException("Plugin is not loaded by PluginClassLoader unexpectedly.");
         }
         Path path = Paths.get(glob);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -1,10 +1,10 @@
 package org.embulk.input.jdbc;
 
 import java.util.Optional;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
-import org.embulk.config.Task;
 import org.embulk.spi.type.Type;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
+import org.embulk.util.config.Task;
 
 public interface JdbcColumnOption
         extends Task

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
@@ -3,8 +3,6 @@ package org.embulk.input.jdbc;
 import java.util.Map;
 import java.util.HashMap;
 import java.util.Properties;
-import com.google.common.base.Function;
-import com.google.common.collect.Maps;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
 // TODO copied from embulk-output-jdbc. Move this class to embulk-core spi.unit.
@@ -14,16 +12,7 @@ public class ToStringMap
     @JsonCreator
     ToStringMap(Map<String, ToString> map)
     {
-        super(Maps.transformValues(map, new Function<ToString, String>() {
-            public String apply(ToString value)
-            {
-                if (value == null) {
-                    return "null";
-                } else {
-                    return value.toString();
-                }
-            }
-        }));
+        super(mapToStringString(map));
     }
 
     public Properties toProperties()
@@ -31,5 +20,18 @@ public class ToStringMap
         Properties props = new Properties();
         props.putAll(this);
         return props;
+    }
+
+    private static Map<String, String> mapToStringString(final Map<String, ToString> mapOfToString) {
+        final HashMap<String, String> result = new HashMap<>();
+        for (final Map.Entry<String, ToString> entry : mapOfToString.entrySet()) {
+            final ToString value = entry.getValue();
+            if (value == null) {
+                result.put(entry.getKey(), null);
+            } else {
+                result.put(entry.getKey(), value.toString());
+            }
+        }
+        return result;
     }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/ToStringMap.java
@@ -5,7 +5,6 @@ import java.util.HashMap;
 import java.util.Properties;
 import com.fasterxml.jackson.annotation.JsonCreator;
 
-// TODO copied from embulk-output-jdbc. Move this class to embulk-core spi.unit.
 public class ToStringMap
         extends HashMap<String, String>
 {
@@ -27,7 +26,7 @@ public class ToStringMap
         for (final Map.Entry<String, ToString> entry : mapOfToString.entrySet()) {
             final ToString value = entry.getValue();
             if (value == null) {
-                result.put(entry.getKey(), null);
+                result.put(entry.getKey(), "null");
             } else {
                 result.put(entry.getKey(), value.toString());
             }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/AbstractColumnGetter.java
@@ -102,4 +102,30 @@ public abstract class AbstractColumnGetter implements ColumnGetter, ColumnVisito
                             "Converting last_record value %s to column index %d is not supported",
                             fromValue.toString(), toIndex));
     }
+
+    final long roundDoubleToLong(final double value) {
+        // TODO configurable rounding mode
+        if (Math.getExponent(value) > Double.MAX_EXPONENT) {
+            throw new ArithmeticException("input is infinite or NaN");
+        }
+        final double z = Math.rint(value);
+        if (Math.abs(value - z) == 0.5) {
+            return (long) (value + Math.copySign(0.5, value));
+        } else {
+            return (long) z;
+        }
+    }
+
+    final long roundFloatToLong(final float value) {
+        // TODO configurable rounding mode
+        if (Math.getExponent(value) > Double.MAX_EXPONENT) {
+            throw new ArithmeticException("input is infinite or NaN");
+        }
+        final double z = Math.rint(value);
+        if (Math.abs(value - z) == 0.5) {
+            return (long) (value + Math.copySign(0.5, value));
+        } else {
+            return (long) z;
+        }
+    }
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.Task;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin.PluginTask;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -17,6 +16,7 @@ import org.embulk.spi.Exec;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.TimestampType;
 import org.embulk.spi.type.Type;
+import org.embulk.util.config.Task;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 import static java.util.Locale.ENGLISH;

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DoubleColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DoubleColumnGetter.java
@@ -41,16 +41,7 @@ public class DoubleColumnGetter
     {
         long l;
         try {
-            // TODO configurable rounding mode
-            if (Math.getExponent(value) > Double.MAX_EXPONENT) {
-                throw new ArithmeticException("input is infinite or NaN");
-            }
-            final double z = Math.rint(value);
-            if (Math.abs(value - z) == 0.5) {
-                l = (long) (value + Math.copySign(0.5, value));
-            } else {
-                l = (long) z;
-            }
+            l = roundDoubleToLong(this.value);
         } catch (ArithmeticException e) {
             // NaN / Infinite / -Infinite
             super.longColumn(column);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DoubleColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/DoubleColumnGetter.java
@@ -7,7 +7,6 @@ import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
-import com.google.common.math.DoubleMath;
 
 public class DoubleColumnGetter
         extends AbstractColumnGetter
@@ -43,7 +42,15 @@ public class DoubleColumnGetter
         long l;
         try {
             // TODO configurable rounding mode
-            l = DoubleMath.roundToLong(value, RoundingMode.HALF_UP);
+            if (Math.getExponent(value) > Double.MAX_EXPONENT) {
+                throw new ArithmeticException("input is infinite or NaN");
+            }
+            final double z = Math.rint(value);
+            if (Math.abs(value - z) == 0.5) {
+                l = (long) (value + Math.copySign(0.5, value));
+            } else {
+                l = (long) z;
+            }
         } catch (ArithmeticException e) {
             // NaN / Infinite / -Infinite
             super.longColumn(column);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/FloatColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/FloatColumnGetter.java
@@ -7,7 +7,6 @@ import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
-import com.google.common.math.DoubleMath;
 
 public class FloatColumnGetter
         extends AbstractColumnGetter
@@ -43,7 +42,15 @@ public class FloatColumnGetter
         long l;
         try {
             // TODO configurable rounding mode
-            l = DoubleMath.roundToLong(value, RoundingMode.HALF_UP);
+            if (Math.getExponent(value) > Double.MAX_EXPONENT) {
+                throw new ArithmeticException("input is infinite or NaN");
+            }
+            final double z = Math.rint(value);
+            if (Math.abs(value - z) == 0.5) {
+                l = (long) (value + Math.copySign(0.5, value));
+            } else {
+                l = (long) z;
+            }
         } catch (ArithmeticException e) {
             // NaN / Infinite / -Infinite
             super.longColumn(column);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/FloatColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/FloatColumnGetter.java
@@ -41,16 +41,7 @@ public class FloatColumnGetter
     {
         long l;
         try {
-            // TODO configurable rounding mode
-            if (Math.getExponent(value) > Double.MAX_EXPONENT) {
-                throw new ArithmeticException("input is infinite or NaN");
-            }
-            final double z = Math.rint(value);
-            if (Math.abs(value - z) == 0.5) {
-                l = (long) (value + Math.copySign(0.5, value));
-            } else {
-                l = (long) z;
-            }
+            l = roundFloatToLong(this.value);
         } catch (ArithmeticException e) {
             // NaN / Infinite / -Infinite
             super.longColumn(column);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/JsonColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/JsonColumnGetter.java
@@ -6,10 +6,10 @@ import java.sql.SQLException;
 import org.embulk.input.jdbc.getter.AbstractColumnGetter;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.json.JsonParseException;
-import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.json.JsonParseException;
+import org.embulk.util.json.JsonParser;
 import org.msgpack.value.Value;
 
 public class JsonColumnGetter

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/StringColumnGetter.java
@@ -6,10 +6,10 @@ import java.sql.SQLException;
 import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.json.JsonParseException;
-import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Type;
 import org.embulk.spi.type.Types;
+import org.embulk.util.json.JsonParseException;
+import org.embulk.util.json.JsonParser;
 import org.msgpack.value.Value;
 
 public class StringColumnGetter

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/TimestampWithTimeZoneIncrementalHandler.java
@@ -12,9 +12,9 @@ import java.util.Optional;
 
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.Task;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
+import org.embulk.util.config.Task;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 public class TimestampWithTimeZoneIncrementalHandler

--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -4,7 +4,12 @@ dependencies {
     compileOnly "mysql:mysql-connector-java:5.1.44"
     defaultJdbcDriver 'mysql:mysql-connector-java:5.1.44'
 
-    testCompile 'org.embulk:embulk-standards:0.9.23'
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
+
     testCompile "mysql:mysql-connector-java:5.1.44"
 }
 

--- a/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,5 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -8,16 +8,14 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import com.google.common.base.Throwables;
-
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.Ssl;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.mysql.MySQLInputConnection;
 import org.embulk.input.mysql.getter.MySQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -172,7 +170,7 @@ public class MySQLInputPlugin
             }
         }
         catch (ClassNotFoundException | IllegalAccessException | NoSuchFieldException | IOException e) {
-            throw Throwables.propagate(e);
+            throw new RuntimeException(e);
         }
         finally {
             if (f != null) {

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/AbstractMySQLTimestampIncrementalHandler.java
@@ -2,11 +2,11 @@ package org.embulk.input.mysql.getter;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import org.embulk.config.ConfigSource;
-import org.embulk.config.Task;
 import org.embulk.input.jdbc.getter.AbstractIncrementalHandler;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.embulk.spi.Column;
 import org.embulk.spi.Exec;
+import org.embulk.util.config.Task;
 import org.embulk.util.timestamp.TimestampFormatter;
 
 import java.sql.PreparedStatement;

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -15,8 +15,6 @@ import org.embulk.spi.type.Types;
 import java.time.ZoneId;
 import java.util.TimeZone;
 
-import static com.google.common.base.Preconditions.checkNotNull;
-
 public class MySQLColumnGetterFactory
         extends ColumnGetterFactory
 {

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
@@ -4,8 +4,16 @@ import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.exec.PartialExecutionException;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.MySQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -37,6 +45,10 @@ public class BasicTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "mysql", MySQLInputPlugin.class)
             .build();
 

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/IncrementalTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/IncrementalTest.java
@@ -2,8 +2,16 @@ package org.embulk.input.mysql;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.MySQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.embulk.test.TestingEmbulk.RunResult;
@@ -34,6 +42,10 @@ public class IncrementalTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "mysql", MySQLInputPlugin.class)
             .build();
 

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -1,5 +1,6 @@
 package org.embulk.input.mysql;
 
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Optional;
 import org.embulk.config.TaskSource;
 import org.embulk.input.jdbc.JdbcColumn;
@@ -52,7 +53,20 @@ public class MySQLColumnGetterFactoryTest
             }
 
             @Override
+            @SuppressWarnings("deprecation")
             public TaskSource dump()
+            {
+                return null;
+            }
+
+            @Override
+            public TaskSource toTaskSource()
+            {
+                return null;
+            }
+
+            @Override
+            public ObjectNode toObjectNode()
             {
                 return null;
             }

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLTests.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLTests.java
@@ -9,8 +9,6 @@ import org.embulk.test.EmbulkTests;
 
 import java.io.IOException;
 
-import jnr.ffi.Platform;
-import jnr.ffi.Platform.OS;
 import static java.util.Locale.ENGLISH;
 
 public class MySQLTests
@@ -58,7 +56,7 @@ public class MySQLTests
 
     private static String convert(String sql)
     {
-        if (Platform.getNativePlatform().getOS().equals(OS.WINDOWS)) {
+        if (System.getProperty("os.name").contains("Windows")) {
             // '"' should be '\"' and '\' should be '\\' in Windows
             return sql.replace("\\\\", "\\").replace("\\", "\\\\").replace("\"", "\\\"");
         }

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/OptionTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/OptionTest.java
@@ -1,8 +1,17 @@
 package org.embulk.input.mysql;
 
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.MySQLInputPlugin;
+import org.embulk.input.MySQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -33,6 +42,10 @@ public class OptionTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "mysql", MySQLInputPlugin.class)
             .build();
 

--- a/embulk-input-oracle/build.gradle
+++ b/embulk-input-oracle/build.gradle
@@ -1,7 +1,12 @@
 dependencies {
     compile(project(path: ":embulk-input-jdbc", configuration: "runtimeElements"))
 
-    testCompile 'org.embulk:embulk-standards:0.9.23'
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
+
     testCompile files('test_jdbc_driver/ojdbc7.jar')
 }
 

--- a/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,5 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -1,14 +1,14 @@
 package org.embulk.input;
 
 import java.util.Optional;
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.oracle.OracleInputConnection;
 import org.embulk.input.oracle.getter.OracleColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 import java.sql.Connection;
 import java.sql.DriverManager;

--- a/embulk-input-oracle/src/test/java/org/embulk/input/oracle/BasicTest.java
+++ b/embulk-input-oracle/src/test/java/org/embulk/input/oracle/BasicTest.java
@@ -2,8 +2,16 @@ package org.embulk.input.oracle;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.OracleInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -33,6 +41,10 @@ public class BasicTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "oracle", OracleInputPlugin.class)
             .build();
 

--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -4,7 +4,12 @@ dependencies {
     compileOnly "org.postgresql:postgresql:9.4-1205-jdbc41"
     defaultJdbcDriver 'org.postgresql:postgresql:9.4-1205-jdbc41'
 
-    testCompile 'org.embulk:embulk-standards:0.9.23'
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
+
     testCompile "org.postgresql:postgresql:9.4-1205-jdbc41"
 }
 

--- a/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,5 +1,12 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -6,13 +6,13 @@ import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.util.Optional;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
 import org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 public class PostgreSQLInputPlugin
         extends AbstractJdbcInputPlugin

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/ArrayColumnGetter.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/ArrayColumnGetter.java
@@ -5,9 +5,9 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import org.embulk.input.jdbc.getter.AbstractColumnGetter;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.json.JsonParseException;
-import org.embulk.spi.json.JsonParser;
 import org.embulk.spi.type.Type;
+import org.embulk.util.json.JsonParseException;
+import org.embulk.util.json.JsonParser;
 import org.msgpack.value.Value;
 
 import java.math.BigDecimal;

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/HstoreToJsonColumnGetter.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/HstoreToJsonColumnGetter.java
@@ -5,8 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import org.embulk.input.jdbc.getter.JsonColumnGetter;
 import org.embulk.spi.Column;
 import org.embulk.spi.PageBuilder;
-import org.embulk.spi.json.JsonParseException;
 import org.embulk.spi.type.Type;
+import org.embulk.util.json.JsonParseException;
 import org.msgpack.value.Value;
 import org.postgresql.util.HStoreConverter;
 

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
@@ -1,8 +1,16 @@
 package org.embulk.input.postgresql;
 
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -32,6 +40,10 @@ public class ArrayTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+        .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+        .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+        .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+        .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
         .registerPlugin(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class)
         .build();
 

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/HstoreTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/HstoreTest.java
@@ -4,8 +4,16 @@ import java.nio.file.Path;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.TestingEmbulk.RunResult;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
@@ -34,6 +42,10 @@ public class HstoreTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+        .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+        .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+        .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+        .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
         .registerPlugin(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class)
         .build();
 

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/IncrementalTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/IncrementalTest.java
@@ -4,8 +4,16 @@ import java.nio.file.Path;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.TestingEmbulk.RunResult;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
@@ -34,6 +42,10 @@ public class IncrementalTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+        .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+        .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+        .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+        .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
         .registerPlugin(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class)
         .build();
 

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLTests.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/PostgreSQLTests.java
@@ -4,8 +4,6 @@ import org.embulk.test.EmbulkTests;
 import com.google.common.base.Throwables;
 import com.google.common.io.ByteStreams;
 import java.io.IOException;
-import jnr.ffi.Platform;
-import jnr.ffi.Platform.OS;
 import org.embulk.config.ConfigSource;
 import static java.util.Locale.ENGLISH;
 
@@ -44,7 +42,7 @@ public class PostgreSQLTests
 
     private static String convert(String sql)
     {
-        if (Platform.getNativePlatform().getOS().equals(OS.WINDOWS)) {
+        if (System.getProperty("os.name").contains("Windows")) {
             // '"' should be '\"' and '\' should be '\\' in Windows
             return sql.replace("\\\\", "\\").replace("\\", "\\\\").replace("\"", "\\\"");
         }

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/UUIDTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/UUIDTest.java
@@ -8,8 +8,16 @@ import static org.junit.Assert.assertThat;
 import java.nio.file.Path;
 
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.PostgreSQLInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.embulk.test.TestingEmbulk.RunResult;
@@ -33,6 +41,10 @@ public class UUIDTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+        .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+        .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+        .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+        .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
         .registerPlugin(InputPlugin.class, "postgresql", PostgreSQLInputPlugin.class)
         .build();
 

--- a/embulk-input-redshift/build.gradle
+++ b/embulk-input-redshift/build.gradle
@@ -5,7 +5,11 @@ dependencies {
 
     testCompile project(':embulk-input-jdbc').sourceSets.test.output
 
-    testCompile 'org.embulk:embulk-standards:0.9.23'
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
 }
 
 embulkPlugin {

--- a/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,6 +1,13 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
+javax.validation:validation-api:1.1.0.Final
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
 org.postgresql:postgresql:9.4-1205-jdbc41

--- a/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
@@ -5,14 +5,13 @@ import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
 
-
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
 import org.embulk.input.redshift.getter.RedshiftColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 
 public class RedshiftInputPlugin
         extends AbstractJdbcInputPlugin

--- a/embulk-input-redshift/src/test/java/org/embulk/input/redshift/IncrementalTest.java
+++ b/embulk-input-redshift/src/test/java/org/embulk/input/redshift/IncrementalTest.java
@@ -2,8 +2,16 @@ package org.embulk.input.redshift;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.RedshiftInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.embulk.test.TestingEmbulk.RunResult;
@@ -34,6 +42,10 @@ public class IncrementalTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "redshift", RedshiftInputPlugin.class)
             .build();
 

--- a/embulk-input-sqlserver/build.gradle
+++ b/embulk-input-sqlserver/build.gradle
@@ -3,7 +3,11 @@ dependencies {
     compile 'com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8'
     compile 'net.sourceforge.jtds:jtds:1.3.1'
 
-    testCompile 'org.embulk:embulk-standards:0.9.23'
+    testCompile "com.google.guava:guava:18.0"
+    testCompile "org.embulk:embulk-formatter-csv:0.10.31"
+    testCompile "org.embulk:embulk-input-file:0.10.31"
+    testCompile "org.embulk:embulk-output-file:0.10.31"
+    testCompile "org.embulk:embulk-parser-csv:0.10.31"
 }
 
 embulkPlugin {

--- a/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -1,7 +1,14 @@
 # This is a Gradle generated file for dependency locking.
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
+com.fasterxml.jackson.core:jackson-annotations:2.6.7
+com.fasterxml.jackson.core:jackson-core:2.6.7
+com.fasterxml.jackson.core:jackson-databind:2.6.7
+com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8
+javax.validation:validation-api:1.1.0.Final
 net.sourceforge.jtds:jtds:1.3.1
+org.embulk:embulk-util-config:0.3.0
+org.embulk:embulk-util-json:0.1.0
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -7,16 +7,15 @@ import java.util.Properties;
 import java.util.Optional;
 import javax.validation.constraints.Size;
 
-import org.embulk.config.Config;
-import org.embulk.config.ConfigDefault;
 import org.embulk.config.ConfigException;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.sqlserver.SQLServerInputConnection;
-
 import org.embulk.input.sqlserver.getter.SQLServerColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
+import org.embulk.util.config.Config;
+import org.embulk.util.config.ConfigDefault;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 

--- a/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/BasicTest.java
+++ b/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/BasicTest.java
@@ -9,8 +9,16 @@ import java.nio.file.Path;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.SQLServerInputPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
@@ -33,6 +41,10 @@ public class BasicTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "sqlserver", SQLServerInputPlugin.class)
             .build();
 

--- a/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/IncrementalTest.java
+++ b/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/IncrementalTest.java
@@ -3,7 +3,15 @@ package org.embulk.input.sqlserver;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.input.SQLServerInputPlugin;
+import org.embulk.formatter.csv.CsvFormatterPlugin;
+import org.embulk.input.file.LocalFileInputPlugin;
+import org.embulk.output.file.LocalFileOutputPlugin;
+import org.embulk.parser.csv.CsvParserPlugin;
+import org.embulk.spi.FileInputPlugin;
+import org.embulk.spi.FileOutputPlugin;
+import org.embulk.spi.FormatterPlugin;
 import org.embulk.spi.InputPlugin;
+import org.embulk.spi.ParserPlugin;
 import org.embulk.test.EmbulkTests;
 import org.embulk.test.TestingEmbulk;
 import org.embulk.test.TestingEmbulk.RunResult;
@@ -34,6 +42,10 @@ public class IncrementalTest
 
     @Rule
     public TestingEmbulk embulk = TestingEmbulk.builder()
+            .registerPlugin(FileInputPlugin.class, "file", LocalFileInputPlugin.class)
+            .registerPlugin(ParserPlugin.class, "csv", CsvParserPlugin.class)
+            .registerPlugin(FormatterPlugin.class, "csv", CsvFormatterPlugin.class)
+            .registerPlugin(FileOutputPlugin.class, "file", LocalFileOutputPlugin.class)
             .registerPlugin(InputPlugin.class, "sqlserver", SQLServerInputPlugin.class)
             .build();
 


### PR DESCRIPTION
Getting these `embulk-input-jdbc` plugins caught up with Embulk v0.10+ API/SPI.

See also: https://dev.embulk.org/topics/get-ready-for-v0.11-and-v1.0.html