### PR TITLE
Map an Embulk config directly to ZoneId with embulk-util-config's ZoneIdModule

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcColumnOption.java
@@ -1,5 +1,6 @@
 package org.embulk.input.jdbc;
 
+import java.time.ZoneId;
 import java.util.Optional;
 import org.embulk.spi.type.Type;
 import org.embulk.util.config.Config;
@@ -23,5 +24,5 @@ public interface JdbcColumnOption
 
     @Config("timezone")
     @ConfigDefault("null")
-    public Optional<String> getTimeZone();
+    public Optional<ZoneId> getTimeZone();
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/getter/ColumnGetterFactory.java
@@ -2,6 +2,7 @@ package org.embulk.input.jdbc.getter;
 
 import java.lang.reflect.Field;
 import java.sql.Types;
+import java.time.ZoneId;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
@@ -24,10 +25,10 @@ import static java.util.Locale.ENGLISH;
 public class ColumnGetterFactory
 {
     protected final PageBuilder to;
-    private final String defaultTimeZone;
+    private final ZoneId defaultTimeZone;
     private final Map<Integer, String> jdbcTypes = getAllJDBCTypes();
 
-    public ColumnGetterFactory(PageBuilder to, String defaultTimeZone)
+    public ColumnGetterFactory(PageBuilder to, ZoneId defaultTimeZone)
     {
         this.to = to;
         this.defaultTimeZone = defaultTimeZone;
@@ -182,8 +183,8 @@ public class ColumnGetterFactory
     private TimestampFormatter newTimestampFormatter(JdbcColumnOption option, String defaultTimestampFormat)
     {
         final String format = option.getTimestampFormat().orElse(defaultTimestampFormat);
-        final String timezone = option.getTimeZone().orElse(this.defaultTimeZone);
-        return TimestampFormatter.builder(format, true).setDefaultZoneFromString(timezone).build();
+        final ZoneId timezone = option.getTimeZone().orElse(this.defaultTimeZone);
+        return TimestampFormatter.builder(format, true).setDefaultZoneId(timezone).build();
     }
 
     private static UnsupportedOperationException unsupportedOperationException(JdbcColumn column)

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -6,6 +6,7 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -137,7 +138,7 @@ public class MySQLInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final ZoneId dateTimeZone)
     {
         return new MySQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/getter/MySQLColumnGetterFactory.java
@@ -18,7 +18,7 @@ import java.util.TimeZone;
 public class MySQLColumnGetterFactory
         extends ColumnGetterFactory
 {
-    public MySQLColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
+    public MySQLColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
@@ -19,7 +19,6 @@ import org.embulk.test.TestingEmbulk;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
-
 import java.nio.file.Path;
 
 import static org.embulk.input.mysql.MySQLTests.execute;
@@ -140,12 +139,16 @@ public class BasicTest
         try {
             embulk.runInput(baseConfig.merge(loadYamlResource(embulk, "test_invalid_zone_config.yml")), out1);
         } catch (final PartialExecutionException ex) {
-            final Throwable cause = ex.getCause();
-            assertThat(cause, instanceOf(ConfigException.class));
-            assertThat(cause.getMessage(), is("Time zone 'Somewhere/Some_City' is not recognised."));
-            return;
+            Throwable cause = ex.getCause();
+            while (cause != null) {
+                if (cause.getMessage() != null
+                            && cause.getMessage().contains("\"Somewhere/Some_City\" is not recognized as a timezone name.")) {
+                    return;
+                }
+                cause = cause.getCause();
+            }
         }
-        fail();
+        fail("It did not throw an expected Exception.");
     }
 
     @Test

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/MySQLColumnGetterFactoryTest.java
@@ -2,6 +2,7 @@ package org.embulk.input.mysql;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.Optional;
+import java.time.ZoneId;
 import org.embulk.config.TaskSource;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -41,7 +42,7 @@ public class MySQLColumnGetterFactoryTest
             }
 
             @Override
-            public Optional<String> getTimeZone()
+            public Optional<ZoneId> getTimeZone()
             {
                 return Optional.empty();
             }

--- a/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/OracleInputPlugin.java
@@ -13,6 +13,7 @@ import org.embulk.util.config.ConfigDefault;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Properties;
 
 public class OracleInputPlugin
@@ -134,7 +135,7 @@ public class OracleInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone) {
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final ZoneId dateTimeZone) {
         return new OracleColumnGetterFactory(pageBuilder, dateTimeZone);
     }
 

--- a/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java
+++ b/embulk-input-oracle/src/main/java/org/embulk/input/oracle/getter/OracleColumnGetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.input.oracle.getter;
 
+import java.time.ZoneId;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -12,7 +13,7 @@ import org.embulk.spi.PageBuilder;
 public class OracleColumnGetterFactory extends ColumnGetterFactory
 {
 
-  public OracleColumnGetterFactory(final PageBuilder to, final String defaultTimeZone) {
+  public OracleColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone) {
     super(to, defaultTimeZone);
   }
 

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Optional;
 
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
@@ -106,7 +107,7 @@ public class PostgreSQLInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final ZoneId dateTimeZone)
     {
         return new PostgreSQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/getter/PostgreSQLColumnGetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.input.postgresql.getter;
 
+import java.time.ZoneId;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin.PluginTask;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -14,7 +15,7 @@ import org.embulk.spi.type.Types;
 
 public class PostgreSQLColumnGetterFactory extends ColumnGetterFactory
 {
-    public PostgreSQLColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
+    public PostgreSQLColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }

--- a/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/RedshiftInputPlugin.java
@@ -4,6 +4,7 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.time.ZoneId;
 
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
@@ -95,7 +96,7 @@ public class RedshiftInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final ZoneId dateTimeZone)
     {
         return new RedshiftColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/redshift/getter/RedshiftColumnGetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.input.redshift.getter;
 
+import java.time.ZoneId;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin.PluginTask;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -12,7 +13,7 @@ import org.embulk.spi.PageBuilder;
 
 public class RedshiftColumnGetterFactory extends ColumnGetterFactory
 {
-    public RedshiftColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
+    public RedshiftColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -3,6 +3,7 @@ package org.embulk.input;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
+import java.time.ZoneId;
 import java.util.Properties;
 import java.util.Optional;
 import javax.validation.constraints.Size;
@@ -167,7 +168,7 @@ public class SQLServerInputPlugin
     }
 
     @Override
-    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final String dateTimeZone)
+    protected ColumnGetterFactory newColumnGetterFactory(final PageBuilder pageBuilder, final ZoneId dateTimeZone)
     {
         return new SQLServerColumnGetterFactory(pageBuilder, dateTimeZone);
     }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
@@ -1,5 +1,6 @@
 package org.embulk.input.sqlserver.getter;
 
+import java.time.ZoneId;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.JdbcColumn;
 import org.embulk.input.jdbc.JdbcColumnOption;
@@ -9,7 +10,7 @@ import org.embulk.spi.PageBuilder;
 
 public class SQLServerColumnGetterFactory extends ColumnGetterFactory {
 
-    public SQLServerColumnGetterFactory(final PageBuilder to, final String defaultTimeZone)
+    public SQLServerColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone)
     {
         super(to, defaultTimeZone);
     }


### PR DESCRIPTION
Counter to the past changes in #181. #181 replaced Joda-Time's `DateTimeZone` to `String`, and introduced an explicit check against invalid time zones.

We have `embulk-util-config:0.3.0` for `embulk-input-jdbc` now by #199. It has an additional Jackson `Module` to map an Embulk config into `java.time.ZoneId` directly with some validation.
* https://github.com/embulk/embulk-util-config/pull/16
* https://github.com/embulk/embulk-util-config/pull/22

We can replace the explicit check against invalid time zones by `ZoneIdModule`.

This PR follows #207.