### PR TITLE
Nominate developers in embulk-input-sqlserver

### DIFF
--- a/embulk-input-sqlserver/build.gradle
+++ b/embulk-input-sqlserver/build.gradle
@@ -11,3 +11,38 @@ embulkPlugin {
     category = "input"
     type = "sqlserver"
 }
+
+publishing {
+    publications {
+        maven(MavenPublication) {
+            pom {  // https://central.sonatype.org/pages/requirements.html
+                developers {
+                    developer {
+                        name = "Hitoshi Tanaka"
+                        email = "thitoshi@cac.co.jp"
+                    }
+                    developer {
+                        name = "Sadayuki Furuhashi"
+                        email = "frsyuki@gmail.com"
+                    }
+                    developer {
+                        name = "Muga Nishizawa"
+                        email = "muga.nishizawa@gmail.com"
+                    }
+                    developer {
+                        name = "Shintaro Kimura"
+                        email = "kimura@enigmo.co.jp"
+                    }
+                    developer {
+                        name = "Hieu Duong"
+                        email = "duongminhhieu89@gmail.com"
+                    }
+                    developer {
+                        name = "Dai MIKURUBE"
+                        email = "dmikurube@treasure-data.com"
+                    }
+                }
+            }
+        }
+    }
+}

--- a/embulk-input-sqlserver/build.gradle
+++ b/embulk-input-sqlserver/build.gradle
@@ -31,7 +31,7 @@ publishing {
                     }
                     developer {
                         name = "Shintaro Kimura"
-                        email = "kimura@enigmo.co.jp"
+                        email = "kmrshntr@gmail.com"
                     }
                     developer {
                         name = "Hieu Duong"


### PR DESCRIPTION
Maven Central needs the `<developers>` section available in `pom.xml`. Nominating developers who have contributed in `embulk-input-sqlserver` from the Git log.