### PR TITLE
Change its Maven group to "org.embulk" from "org.embulk.input.jdbc"

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
 }
 
 allprojects {
-    group = 'org.embulk.input.jdbc'
+    group = "org.embulk"
     version = "0.12.0"
     description = "Selects records from a table."
 }


### PR DESCRIPTION
Since other https://github.com/embulk plugins (e.g. https://repo1.maven.org/maven2/org/embulk/embulk-input-s3/ and https://repo1.maven.org/maven2/org/embulk/embulk-input-sftp/) are based on `org.embulk`, changing its group to the same `org.embulk`.