### PR TITLE
Get ready for Maven Central in 0.12.1

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,13 @@
+Release 0.12.1 - 2021-05-31
+
+* Release the JAR artifacts to Maven Central, instead of Bintray
+
+Release 0.12.0 - 2021-05-31
+
+* Catch up with Embulk API/SPI v0.10.
+* Map an Embulk config directly to ZoneId with embulk-util-config's ZoneIdModule
+* Wrap UnknownHostException to ConfigException
+
 Release 0.11.1 - 2020-09-04
 
 * Updated embulk-util-timestamp to 0.2.1 .

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ plugins {
 
 allprojects {
     group = "org.embulk"
-    version = "0.12.0"
+    version = "0.12.1"
     description = "Selects records from a table."
 }
 
@@ -19,12 +19,11 @@ subprojects {
     apply plugin: 'java'
     apply plugin: "maven-publish"
     apply plugin: "signing"
+    apply plugin: "checkstyle"
     apply plugin: "org.embulk.embulk-plugins"
-    //apply plugin: 'jacoco'
 
     repositories {
         mavenCentral()
-        jcenter()
     }
 
     configurations {
@@ -33,6 +32,16 @@ subprojects {
 
     sourceCompatibility = 1.8
     targetCompatibility = 1.8
+
+    tasks.withType(JavaCompile) {
+        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
+        options.encoding = "UTF-8"
+    }
+
+    java {
+        withJavadocJar()
+        withSourcesJar()
+    }
 
     dependencies {
         compileOnly "org.embulk:embulk-api:0.10.31"
@@ -56,19 +65,12 @@ subprojects {
         compile "com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7"
         compile "javax.validation:validation-api:1.1.0.Final"
 
-        compile("org.embulk:embulk-util-json:0.1.0") {
-            exclude group: "org.msgpack", module: "msgpack-core"  // Included in embulk-api.
-        }
+        compile "org.embulk:embulk-util-json:0.1.1"
         compile "org.embulk:embulk-util-timestamp:0.2.1"
 
         testCompile "org.embulk:embulk-junit4:0.10.31"
         testCompile "org.embulk:embulk-core:0.10.31"
         testCompile "org.embulk:embulk-deps:0.10.31"
-    }
-
-    tasks.withType(JavaCompile) {
-        options.compilerArgs << "-Xlint:unchecked" << "-Xlint:deprecation"
-        options.encoding = 'UTF-8'
     }
 
     javadoc {
@@ -145,23 +147,6 @@ subprojects {
             locale = 'en_US'
             encoding = 'UTF-8'
         }
-    }
-
-    // add tests/javadoc/source jar tasks as artifacts to be released
-    task testsJar(type: Jar, dependsOn: classes) {
-        classifier = 'tests'
-        from sourceSets.test.output
-    }
-    task sourcesJar(type: Jar, dependsOn: classes) {
-        classifier = 'sources'
-        from sourceSets.main.allSource
-    }
-    task javadocJar(type: Jar, dependsOn: javadoc) {
-        classifier = 'javadoc'
-        from javadoc.destinationDir
-    }
-    artifacts {
-        archives testsJar, sourcesJar, javadocJar
     }
 
     publishing {

--- a/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-db2/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-jdbc/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-mysql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-oracle/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-postgresql/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,6 +7,6 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1

--- a/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-redshift/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -7,7 +7,7 @@ com.fasterxml.jackson.core:jackson-databind:2.6.7
 com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7
 javax.validation:validation-api:1.1.0.Final
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1
 org.postgresql:postgresql:9.4-1205-jdbc41

--- a/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
+++ b/embulk-input-sqlserver/gradle/dependency-locks/embulkPluginRuntime.lockfile
@@ -9,6 +9,6 @@ com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8
 javax.validation:validation-api:1.1.0.Final
 net.sourceforge.jtds:jtds:1.3.1
 org.embulk:embulk-util-config:0.3.0
-org.embulk:embulk-util-json:0.1.0
+org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-rubytime:0.3.2
 org.embulk:embulk-util-timestamp:0.2.1


### PR DESCRIPTION
I've released `0.12.0` **gems** of `embulk-input-jdbc/mysql/postgresql/redshift/sqlserver`, but I was not able to release JARs into Maven Central because it didn't include `javadocJar` and `sourcesJar`. (Rejected from Maven Central.)

This pull-request adds:
* `javadocJar` and `sourcesJar`
* `ChangeLog` (forgotten)
* update `embulk-util-json` to `0.1.1` (only removing `msgpack-core` from `compile` dependency / no code change)

@hito4t @vietnguyen-td Sorry for adding one more. Could you have a look?