### PR TITLE
Test sqlserver with ubuntu-latest

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -181,7 +181,7 @@ jobs:
         name: redshift
         path: embulk-input-redshift/build/reports/tests/test
   sqlserver:  # https://hub.docker.com/_/microsoft-mssql-server
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
     services:
       sqlserver:
         # To run locallly:
@@ -195,6 +195,10 @@ jobs:
           SA_PASSWORD: "P@ssw0rd"
     steps:
     - uses: actions/checkout@v2
+    - uses: actions/setup-java@v2
+      with:
+        java-version: 8
+        distribution: 'zulu'
     # TODO: Find a better way to wait for completing setup.
     - name: Sleep for 30 seconds to complete all the SQL Server setup process
       run: sleep 30

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -26,7 +26,7 @@ public class SQLServerInputPlugin
     extends AbstractJdbcInputPlugin
 {
     private static final Logger logger = LoggerFactory.getLogger(SQLServerInputPlugin.class);
-    private static int DEFAULT_PORT = 1433;
+    private static final int DEFAULT_PORT = 1433;
 
     public interface SQLServerPluginTask
         extends PluginTask
@@ -81,7 +81,7 @@ public class SQLServerInputPlugin
 
         @Config("application_name")
         @ConfigDefault("\"embulk-input-sqlserver\"")
-        @Size(max=128)
+        @Size(max = 128)
         public String getApplicationName();
     }
 
@@ -132,7 +132,8 @@ public class SQLServerInputPlugin
             catch (Exception e) {
                 throw new ConfigException("Can't load Microsoft SQLServerDriver from classpath", e);
             }
-        } else if (sqlServerTask.getDriverType().equalsIgnoreCase("jtds")) {
+        }
+        else if (sqlServerTask.getDriverType().equalsIgnoreCase("jtds")) {
             useJtdsDriver = true;
             try {
                 driver = (Driver) Class.forName("net.sourceforge.jtds.jdbc.Driver").newInstance();
@@ -140,7 +141,8 @@ public class SQLServerInputPlugin
             catch (Exception e) {
                 throw new ConfigException("Can't load jTDS Driver from classpath", e);
             }
-        } else {
+        }
+        else {
             throw new ConfigException("Unknown driver_type : " + sqlServerTask.getDriverType());
         }
 

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputConnection.java
@@ -4,8 +4,8 @@ import java.sql.Connection;
 import java.sql.SQLException;
 import org.embulk.input.jdbc.JdbcInputConnection;
 
-public class SQLServerInputConnection extends JdbcInputConnection {
-
+public class SQLServerInputConnection extends JdbcInputConnection
+{
     private String transactionIsolationLevel;
 
     public SQLServerInputConnection(Connection connection, String schemaName) throws SQLException
@@ -39,5 +39,4 @@ public class SQLServerInputConnection extends JdbcInputConnection {
         }
         return sb.toString();
     }
-
 }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/getter/SQLServerColumnGetterFactory.java
@@ -8,8 +8,8 @@ import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.getter.*;
 import org.embulk.spi.PageBuilder;
 
-public class SQLServerColumnGetterFactory extends ColumnGetterFactory {
-
+public class SQLServerColumnGetterFactory extends ColumnGetterFactory
+{
     public SQLServerColumnGetterFactory(final PageBuilder to, final ZoneId defaultTimeZone)
     {
         super(to, defaultTimeZone);
@@ -36,5 +36,4 @@ public class SQLServerColumnGetterFactory extends ColumnGetterFactory {
             return super.newColumnGetter(con, task, column, option);
         }
     }
-
 }

--- a/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/SQLServerTests.java
+++ b/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/SQLServerTests.java
@@ -21,6 +21,11 @@ import com.google.common.io.ByteStreams;
 
 public class SQLServerTests
 {
+    private SQLServerTests()
+    {
+        // No instantiation.
+    }
+
     public static ConfigSource baseConfig()
     {
         return EmbulkTests.config("EMBULK_INPUT_SQLSERVER_TEST_CONFIG");
@@ -35,7 +40,8 @@ public class SQLServerTests
         final String sqlcmdCommand = System.getenv("EMBULK_INPUT_SQLSERVER_TEST_SQLCMD_COMMAND");
         if (sqlcmdCommand == null || sqlcmdCommand.isEmpty()) {
             args.add("sqlcmd");
-        } else {
+        }
+        else {
             args.addAll(Arrays.asList(sqlcmdCommand.split(" ")));
         }
 
@@ -60,7 +66,8 @@ public class SQLServerTests
             Process process = pb.start();
             ByteStreams.copy(process.getInputStream(), System.out);
             code = process.waitFor();
-        } catch (IOException | InterruptedException ex) {
+        }
+        catch (IOException | InterruptedException ex) {
             throw Throwables.propagate(ex);
         }
         if (code != 0) {


### PR DESCRIPTION
GitHub Actions on `embulk-input-sqlserver` has stopped working due to the old setting for `os`. Updated `os` to `ubuntu-latest`, added `setup-java` specific to OpenJDK 8, and fixed style errors.