### PR TITLE
add query timeout options

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -135,6 +135,9 @@ public abstract class AbstractJdbcInputPlugin
         //@Config("limit_rows")
         //@ConfigDefault("null")
         //public Optional<Integer> getLimitRows();
+        @Config("query_timeout")
+        @ConfigDefault("-1")
+        public int getQueryTimeout();
 
         @Config("connect_timeout")
         @ConfigDefault("300")

--- a/embulk-input-mysql/README.md
+++ b/embulk-input-mysql/README.md
@@ -37,6 +37,7 @@ MySQL input plugin for Embulk loads records from MySQL.
   - If this value is set to -1:
     - It uses a client-side built statement and fetches all rows at once. This may cause OutOfMemoryError.
     - Internally, `useCursorFetch=false` is used and `java.sql.Statement.setFetchSize` is not set.
+- **query_timeout**: timeout for query connect. -1 means no timeout. (integer (seconds), default: -1)
 - **connect_timeout**: timeout for socket connect. 0 means no timeout. (integer (seconds), default: 300)
 - **socket_timeout**: timeout on network socket operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **ssl**: use SSL to connect to the database (string, default: `disable`. `enable` uses SSL without server-side validation nor verify checks the certificate. For compatibility reasons, `true` behaves as `enable` and `false` behaves as `disable`.)

--- a/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/MySQLInputPlugin.java
@@ -83,7 +83,7 @@ public class MySQLInputPlugin
         props.setProperty("zeroDateTimeBehavior", "convertToNull");
 
         props.setProperty("useCompression", "true");
-
+        props.setProperty("queryTimeout", String.valueOf(t.getQueryTimeout()  * 1000)); // milliseconds
         props.setProperty("connectTimeout", String.valueOf(t.getConnectTimeout() * 1000)); // milliseconds
         props.setProperty("socketTimeout", String.valueOf(t.getSocketTimeout() * 1000)); // milliseconds
 

--- a/embulk-input-postgresql/README.md
+++ b/embulk-input-postgresql/README.md
@@ -17,6 +17,7 @@ PostgreSQL input plugin for Embulk loads records from PostgreSQL.
 - **database**: destination database name (string, required)
 - **schema**: destination schema name (string, default: "public")
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **query_timeout**: timeout for query connect. -1 means no timeout. (integer (seconds), default: -1)
 - **connect_timeout**: timeout for establishment of a database connection. (integer (seconds), default: 300)
 - **socket_timeout**: timeout for socket read operations. 0 means no timeout. (integer (seconds), default: 1800)
 - **ssl**: enables SSL. Data will be encrypted but CA or certification will not be verified (boolean, default: false)

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -74,6 +74,7 @@ public class PostgreSQLInputPlugin
         Properties props = new Properties();
         props.setProperty("user", t.getUser());
         props.setProperty("password", t.getPassword());
+        props.setProperty("queryTimeout", String.valueOf(t.getQueryTimeout())); // seconds
         props.setProperty("loginTimeout", String.valueOf(t.getConnectTimeout())); // seconds
         props.setProperty("socketTimeout", String.valueOf(t.getSocketTimeout())); // seconds
 

--- a/embulk-input-sqlserver/README.md
+++ b/embulk-input-sqlserver/README.md
@@ -34,6 +34,7 @@ embulk "-J-Djava.library.path=C:\drivers" run input-sqlserver.yml
   - **where**: WHERE condition to filter the rows (string, default: no-condition)
   - **order_by**: expression of ORDER BY to sort rows (e.g. `created_at DESC, id ASC`) (string, default: not sorted)
 - **fetch_rows**: number of rows to fetch one time (used for java.sql.Statement#setFetchSize) (integer, default: 10000)
+- **query_timeout**: timeout for query connect. -1 means no timeout. (integer (seconds), default: -1)
 - **connect_timeout**: timeout for the driver to connect. 0 means the default of SQL Server (15 by default). (integer (seconds), default: 300)
 - **application_name**: application name used to identify a connection in profiling and logging tools. (string, default: "embulk-input-sqlserver")
 - **socket_timeout**: timeout for executing the query. 0 means no timeout. (integer (seconds), default: 1800)

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/SQLServerInputPlugin.java
@@ -187,6 +187,7 @@ public class SQLServerInputPlugin
 
         if (useJtdsDriver) {
             // jTDS properties
+            props.setProperty("queryTimeout", String.valueOf(sqlServerTask.getQueryTimeout())); // seconds
             props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
             props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout())); // seconds
 
@@ -197,6 +198,7 @@ public class SQLServerInputPlugin
         }
         else {
             // SQLServerDriver properties
+            props.setProperty("queryTimeout", String.valueOf(sqlServerTask.getQueryTimeout())); // seconds
             props.setProperty("loginTimeout", String.valueOf(sqlServerTask.getConnectTimeout())); // seconds
             props.setProperty("socketTimeout", String.valueOf(sqlServerTask.getSocketTimeout() * 1000L)); // milliseconds
 


### PR DESCRIPTION
add query timeout options 

```
queryTimeoutint-1 | The number of seconds to wait before a timeout has occurred on a query. The default value is -1, which means infinite timeout. Setting this value to 0 also implies to wait indefinitely.
-- | --
```

https://docs.microsoft.com/en-us/sql/connect/jdbc/setting-the-connection-properties?redirectedfrom=MSDN&view=sql-server-ver15