### PR TITLE
call pageBuilder close function to release buffer

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -515,6 +515,7 @@ public abstract class AbstractJdbcInputPlugin
             }
 
             pageBuilder.finish();
+            pageBuilder.close();
 
             // after_select runs after pageBuilder.finish because pageBuilder.finish may fail.
             // TODO Output plugin's transaction might still fail. In that case, after_select is


### PR DESCRIPTION
# Summary

pageBuilder.close is not called and could be cause leak  issue. add pageBuilder.close to to release buffer (buffer.release()) 


# code
```
    @Override
    public void close() {
        this.delegate.close();
    }
```
https://github.com/embulk/embulk/blob/76a0c9922c551f1d7e6b964642a202edab745435/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java#L201

```
    @Deprecated  // https://github.com/embulk/embulk/issues/1321
    public PageBuilder(BufferAllocator allocator, Schema schema, PageOutput output) {
        this(createImplInstance(allocator, schema, output));
    }
```
https://github.com/embulk/embulk/blob/76a0c9922c551f1d7e6b964642a202edab745435/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java#L49

```
    private static PageBuilder createImplInstance(final BufferAllocator allocator, final Schema schema, final PageOutput output) {
        try {
            return Holder.CONSTRUCTOR.newInstance(allocator, schema, output);
        } catch (final IllegalAccessException | IllegalArgumentException | InstantiationException ex) {
            throw new LinkageError("[FATAL] org.embulk.spi.PageBuilderImpl is invalid.", ex);
        } catch (final InvocationTargetException ex) {
            throwCheckedForcibly(ex.getTargetException());
            return null;  // Should never reach.
        }
    }
```

https://github.com/embulk/embulk/blob/76a0c9922c551f1d7e6b964642a202edab745435/embulk-api/src/main/java/org/embulk/spi/PageBuilder.java#L204

```
    @Override
    public void close() {
        if (buffer != null) {
            buffer.release();
            buffer = null;
            bufferSlice = null;
        }
        output.close();
    }
```
https://github.com/embulk/embulk/blob/76a0c9922c551f1d7e6b964642a202edab745435/embulk-core/src/main/java/org/embulk/spi/PageBuilderImpl.java#L247



# releated
https://github.com/embulk/embulk/issues/1218#issuecomment-586336178