### PR TITLE
Use the MySQL/PostgreSQL JDBC driver found in the class loader in the highest priority

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -1,7 +1,6 @@
 package org.embulk.input.jdbc;
 
 import java.io.File;
-import java.io.FileFilter;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.net.MalformedURLException;
@@ -649,43 +648,6 @@ public abstract class AbstractJdbcInputPlugin
     //        pages = Collections.unmodifiableList(builder);
     //    }
     //}
-
-    protected void loadDriver(String className, Optional<String> driverPath)
-    {
-        if (driverPath.isPresent()) {
-            addDriverJarToClasspath(driverPath.get());
-        } else {
-            try {
-                // Gradle test task will add JDBC driver to classpath
-                Class.forName(className);
-
-            } catch (ClassNotFoundException ex) {
-                File root = findPluginRoot();
-                File driverLib = new File(root, "default_jdbc_driver");
-                File[] files = driverLib.listFiles(new FileFilter() {
-                    @Override
-                    public boolean accept(File file) {
-                        return file.isFile() && file.getName().endsWith(".jar");
-                    }
-                });
-                if (files == null || files.length == 0) {
-                    throw new RuntimeException("Cannot find JDBC driver in '" + root.getAbsolutePath() + "'.");
-                } else {
-                    for (File file : files) {
-                        logger.info("JDBC Driver = " + file.getAbsolutePath());
-                        addDriverJarToClasspath(file.getAbsolutePath());
-                    }
-                }
-            }
-        }
-
-        // Load JDBC Driver
-        try {
-            Class.forName(className);
-        } catch (ClassNotFoundException ex) {
-            throw new RuntimeException(ex);
-        }
-    }
 
     protected void addDriverJarToClasspath(String glob)
     {

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/PostgreSQLInputPlugin.java
@@ -1,12 +1,16 @@
 package org.embulk.input;
 
-import java.util.Properties;
+import java.io.File;
+import java.io.FileFilter;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
 import java.time.ZoneId;
 import java.util.Optional;
+import java.util.Properties;
+import java.util.concurrent.atomic.AtomicReference;
 
+import org.embulk.config.ConfigException;
 import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
 import org.embulk.input.jdbc.getter.ColumnGetterFactory;
 import org.embulk.input.postgresql.PostgreSQLInputConnection;
@@ -14,6 +18,8 @@ import org.embulk.input.postgresql.getter.PostgreSQLColumnGetterFactory;
 import org.embulk.spi.PageBuilder;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class PostgreSQLInputPlugin
         extends AbstractJdbcInputPlugin
@@ -70,7 +76,7 @@ public class PostgreSQLInputPlugin
     {
         PostgreSQLPluginTask t = (PostgreSQLPluginTask) task;
 
-        loadDriver("org.postgresql.Driver", t.getDriverPath());
+        this.loadPgJdbcDriver("org.postgresql.Driver", t.getDriverPath());
 
         String url = String.format("jdbc:postgresql://%s:%d/%s",
                 t.getHost(), t.getPort(), t.getDatabase());
@@ -115,4 +121,79 @@ public class PostgreSQLInputPlugin
     {
         return new PostgreSQLColumnGetterFactory(pageBuilder, dateTimeZone);
     }
+
+    private Class<? extends java.sql.Driver> loadPgJdbcDriver(
+            final String className,
+            final Optional<String> driverPath)
+    {
+        synchronized (pgJdbcDriver) {
+            if (pgJdbcDriver.get() != null) {
+                return pgJdbcDriver.get();
+            }
+
+            try {
+                // If the class is found from the ClassLoader of the plugin, that is prioritized the highest.
+                final Class<? extends java.sql.Driver> found = loadJdbcDriverClassForName(className);
+                pgJdbcDriver.compareAndSet(null, found);
+
+                if (driverPath.isPresent()) {
+                    logger.warn(
+                            "\"driver_path\" is set while the Pg JDBC driver class \"{}\" is found from the PluginClassLoader."
+                                    + " \"driver_path\" is ignored.", className);
+                }
+                return found;
+            }
+            catch (final ClassNotFoundException ex) {
+                // Pass-through once.
+            }
+
+            if (driverPath.isPresent()) {
+                logger.info(
+                        "\"driver_path\" is set to load the Pg JDBC driver class \"{}\". Adding it to classpath.", className);
+                this.addDriverJarToClasspath(driverPath.get());
+            }
+            else {
+                final File root = this.findPluginRoot();
+                final File driverLib = new File(root, "default_jdbc_driver");
+                final File[] files = driverLib.listFiles(new FileFilter() {
+                    @Override
+                    public boolean accept(final File file)
+                    {
+                        return file.isFile() && file.getName().endsWith(".jar");
+                    }
+                });
+                if (files == null || files.length == 0) {
+                    throw new ConfigException(new ClassNotFoundException(
+                            "The Pg JDBC driver for the class \"" + className + "\" is not found"
+                                    + " in \"default_jdbc_driver\" (" + root.getAbsolutePath() + ")."));
+                }
+                for (final File file : files) {
+                    logger.info(
+                            "The Pg JDBC driver for the class \"{}\" is expected to be found"
+                                    + " in \"default_jdbc_driver\" at {}.", className, file.getAbsolutePath());
+                    this.addDriverJarToClasspath(file.getAbsolutePath());
+                }
+            }
+
+            try {
+                // Retrying to find the class from the ClassLoader of the plugin.
+                final Class<? extends java.sql.Driver> found = loadJdbcDriverClassForName(className);
+                pgJdbcDriver.compareAndSet(null, found);
+                return found;
+            }
+            catch (final ClassNotFoundException ex) {
+                throw new ConfigException("The Pg JDBC driver for the class \"" + className + "\" is not found.", ex);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private static Class<? extends java.sql.Driver> loadJdbcDriverClassForName(final String className) throws ClassNotFoundException
+    {
+        return (Class<? extends java.sql.Driver>) Class.forName(className);
+    }
+
+    private static final AtomicReference<Class<? extends java.sql.Driver>> pgJdbcDriver = new AtomicReference<>();
+
+    private static final Logger logger = LoggerFactory.getLogger(PostgreSQLInputPlugin.class);
 }


### PR DESCRIPTION
The JDBC plugins will be available as Maven-based plugins. To make it realized, their `pom.xml` should include MySQL/PostgreSQL JDBC drivers so that Embulk's `PluginClassLoader` can find the JDBC drivers from `pom.xml`. Then, they are loaded straightforward from the class loader.

But currently, their driver finding mechanism does not prioritize classes found straightforward from the class loader.

This pull request changes the priority, including some refactoring with exception/log message changes.