### PR TITLE
Move packages of plugin classes from org.embulk.input

### DIFF
--- a/embulk-input-jdbc/build.gradle
+++ b/embulk-input-jdbc/build.gradle
@@ -2,7 +2,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.JdbcInputPlugin"
+    mainClass = "org.embulk.input.jdbc.JdbcInputPlugin"
     category = "input"
     type = "jdbc"
 }

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.jdbc;
 
 import java.util.Set;
 import java.util.HashSet;
@@ -7,8 +7,6 @@ import java.util.Properties;
 import java.sql.Connection;
 import java.sql.Driver;
 import java.sql.SQLException;
-import org.embulk.input.jdbc.AbstractJdbcInputPlugin;
-import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.util.config.Config;
 import org.embulk.util.config.ConfigDefault;
 

--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.MySQLInputPlugin"
+    mainClass = "org.embulk.input.mysql.MySQLInputPlugin"
     category = "input"
     type = "mysql"
     additionalDependencyDeclarations = [

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputPlugin.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.mysql;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/BasicTest.java
@@ -5,7 +5,6 @@ import org.embulk.config.ConfigException;
 import org.embulk.config.ConfigSource;
 import org.embulk.exec.PartialExecutionException;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.MySQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/IncrementalTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/IncrementalTest.java
@@ -3,7 +3,6 @@ package org.embulk.input.mysql;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.MySQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-mysql/src/test/java/org/embulk/input/mysql/OptionTest.java
+++ b/embulk-input-mysql/src/test/java/org/embulk/input/mysql/OptionTest.java
@@ -2,8 +2,6 @@ package org.embulk.input.mysql;
 
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.MySQLInputPlugin;
-import org.embulk.input.MySQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.PostgreSQLInputPlugin"
+    mainClass = "org.embulk.input.postgresql.PostgreSQLInputPlugin"
     category = "input"
     type = "postgresql"
     additionalDependencyDeclarations = [

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputPlugin.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.postgresql;
 
 import java.io.File;
 import java.io.FileFilter;

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/ArrayTest.java
@@ -2,7 +2,6 @@ package org.embulk.input.postgresql;
 
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.PostgreSQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/HstoreTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/HstoreTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.PostgreSQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/IncrementalTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/IncrementalTest.java
@@ -5,7 +5,6 @@ import java.nio.file.Path;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.PostgreSQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/UUIDTest.java
+++ b/embulk-input-postgresql/src/test/java/org/embulk/input/postgresql/UUIDTest.java
@@ -9,7 +9,6 @@ import java.nio.file.Path;
 
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.PostgreSQLInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-redshift/build.gradle
+++ b/embulk-input-redshift/build.gradle
@@ -13,7 +13,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.RedshiftInputPlugin"
+    mainClass = "org.embulk.input.redshift.RedshiftInputPlugin"
     category = "input"
     type = "redshift"
 }

--- a/embulk-input-redshift/src/main/java/org/embulk/input/redshift/RedshiftInputPlugin.java
+++ b/embulk-input-redshift/src/main/java/org/embulk/input/redshift/RedshiftInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.redshift;
 
 import java.util.Optional;
 import java.util.Properties;

--- a/embulk-input-redshift/src/test/java/org/embulk/input/redshift/IncrementalTest.java
+++ b/embulk-input-redshift/src/test/java/org/embulk/input/redshift/IncrementalTest.java
@@ -3,7 +3,6 @@ package org.embulk.input.redshift;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.RedshiftInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-sqlserver/build.gradle
+++ b/embulk-input-sqlserver/build.gradle
@@ -16,7 +16,7 @@ dependencies {
 }
 
 embulkPlugin {
-    mainClass = "org.embulk.input.SQLServerInputPlugin"
+    mainClass = "org.embulk.input.sqlserver.SQLServerInputPlugin"
     category = "input"
     type = "sqlserver"
 }

--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputPlugin.java
@@ -1,4 +1,4 @@
-package org.embulk.input;
+package org.embulk.input.sqlserver;
 
 import java.sql.Connection;
 import java.sql.Driver;

--- a/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/BasicTest.java
+++ b/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/BasicTest.java
@@ -10,7 +10,6 @@ import java.nio.file.Path;
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
-import org.embulk.input.SQLServerInputPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;
 import org.embulk.parser.csv.CsvParserPlugin;

--- a/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/IncrementalTest.java
+++ b/embulk-input-sqlserver/src/test/java/org/embulk/input/sqlserver/IncrementalTest.java
@@ -2,7 +2,6 @@ package org.embulk.input.sqlserver;
 
 import org.embulk.config.ConfigDiff;
 import org.embulk.config.ConfigSource;
-import org.embulk.input.SQLServerInputPlugin;
 import org.embulk.formatter.csv.CsvFormatterPlugin;
 import org.embulk.input.file.LocalFileInputPlugin;
 import org.embulk.output.file.LocalFileOutputPlugin;


### PR DESCRIPTION
Java 11+ "modules" do not allow that multiple JAR files provide the same Java "package".

Historically, the plugin classes of all JDBC Input plugins have been in `org.embulk.input`, not `org.embulk.input.jdbc`, `org.embulk.input.mysql`, ... `JdbcInputPlugin` has been in `org.embulk.input`, `MySQLInputPlugin` has been also in `org.embulk.input`, `PostgreSQLInputPlugin` has been also in `org.embulk.input`, ...

Therefore, the JDBC plugins can have troubles to work with Java 11+.

This pull request is to get it fixed although it can be incompatible with other plugins that depend on JDBC plugins.