### PR TITLE
Update postgresql JDBC driver version for supporting scram-sha-256

### DIFF
--- a/embulk-input-postgresql/build.gradle
+++ b/embulk-input-postgresql/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compile(project(path: ":embulk-input-jdbc", configuration: "runtimeElements"))
 
-    compileOnly "org.postgresql:postgresql:9.4-1205-jdbc41"
-    defaultJdbcDriver 'org.postgresql:postgresql:9.4-1205-jdbc41'
+    compileOnly "org.postgresql:postgresql:42.4.0"
+    defaultJdbcDriver 'org.postgresql:postgresql:42.4.0'
 
     testCompile "com.google.guava:guava:18.0"
     testCompile "org.embulk:embulk-formatter-csv:0.10.36"
@@ -10,7 +10,7 @@ dependencies {
     testCompile "org.embulk:embulk-output-file:0.10.36"
     testCompile "org.embulk:embulk-parser-csv:0.10.36"
 
-    testCompile "org.postgresql:postgresql:9.4-1205-jdbc41"
+    testCompile "org.postgresql:postgresql:42.4.0"
 }
 
 embulkPlugin {
@@ -18,7 +18,7 @@ embulkPlugin {
     category = "input"
     type = "postgresql"
     additionalDependencyDeclarations = [
-        [ groupId: "org.postgresql", artifactId: "postgresql", version: "9.4-1205-jdbc41", scope: "compile", optional: true ],
+        [ groupId: "org.postgresql", artifactId: "postgresql", version: "42.4.0", scope: "compile", optional: true ],
     ]
 }
 

--- a/embulk-input-postgresql/gradle/dependency-locks/compileClasspath.lockfile
+++ b/embulk-input-postgresql/gradle/dependency-locks/compileClasspath.lockfile
@@ -12,5 +12,5 @@ org.embulk:embulk-util-config:0.3.1
 org.embulk:embulk-util-json:0.1.1
 org.embulk:embulk-util-timestamp:0.2.1
 org.msgpack:msgpack-core:0.8.11
-org.postgresql:postgresql:9.4-1205-jdbc41
+org.postgresql:postgresql:42.4.0
 org.slf4j:slf4j-api:1.7.30


### PR DESCRIPTION
This PR supports scram-sha-256 password encryption in embulk-input-postgresql plugin by default.

When I get to setup embulk-input-postgresql plugin for PostgreSQL 14.4, I get an "authentication method 10 not supported" error.

It seems that scram-sha-256 password encryption needs JDBC >= 42.2.0.
https://www.postgresql.org/about/news/jdbc-4220-released-1825/

Here is an example of a testing with PostgreSQL 14.4 by locally built gem.
`checker-qual-3.5.0.jar` is a runtime dependency of the jdbc.

```
$ embulk preview test.liquid.yml
2022-07-31 23:44:48.872 +0900: Embulk v0.9.24
2022-07-31 23:44:49.754 +0900 [WARN] (main): DEPRECATION: JRuby org.jruby.embed.ScriptingContainer is directly injected.
2022-07-31 23:44:51.851 +0900 [INFO] (main): Gem's home and path are set by default: "/Users/manami/.embulk/lib/gems"
2022-07-31 23:44:52.388 +0900 [INFO] (main): Started Embulk v0.9.24
2022-07-31 23:44:52.499 +0900 [INFO] (0001:preview): Loaded plugin embulk-input-postgresql (0.13.0)
2022-07-31 23:44:52.545 +0900 [WARN] (0001:preview): "UTC" is recognized as "Z" to be compatible with the legacy style.
2022-07-31 23:44:52.553 +0900 [INFO] (0001:preview): The Pg JDBC driver for the class "org.postgresql.Driver" is expected to be found in "default_jdbc_driver" at /Users/manami/.embulk/lib/gems/gems/embulk-input-postgresql-0.13.0-java/default_jdbc_driver/checker-qual-3.5.0.jar.
2022-07-31 23:44:52.554 +0900 [INFO] (0001:preview): The Pg JDBC driver for the class "org.postgresql.Driver" is expected to be found in "default_jdbc_driver" at /Users/manami/.embulk/lib/gems/gems/embulk-input-postgresql-0.13.0-java/default_jdbc_driver/postgresql-42.4.0.jar.
2022-07-31 23:44:52.559 +0900 [INFO] (0001:preview): Connecting to jdbc:postgresql://127.0.0.1:5432/mydatabase options {ApplicationName=embulk-input-postgresql, user=admin, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-07-31 23:44:52.720 +0900 [INFO] (0001:preview): SQL: SET search_path TO "public"
2022-07-31 23:44:52.725 +0900 [INFO] (0001:preview): Using JDBC Driver 42.4.0
2022-07-31 23:44:52.786 +0900 [WARN] (0001:preview): Z is deprecated as a military time zone name. Use UTC instead.
2022-07-31 23:44:52.786 +0900 [WARN] (0001:preview): "Z" is recognized as "Z" to be compatible with the legacy style.
2022-07-31 23:44:52.819 +0900 [INFO] (0001:preview): Connecting to jdbc:postgresql://127.0.0.1:5432/mydatabase options {ApplicationName=embulk-input-postgresql, user=admin, password=***, tcpKeepAlive=true, loginTimeout=300, socketTimeout=1800}
2022-07-31 23:44:52.840 +0900 [INFO] (0001:preview): SQL: SET search_path TO "public"
2022-07-31 23:44:52.844 +0900 [INFO] (0001:preview): SQL: DECLARE cur NO SCROLL CURSOR FOR SELECT * FROM "mytable"
2022-07-31 23:44:52.847 +0900 [INFO] (0001:preview): SQL: FETCH FORWARD 10000 FROM cur
2022-07-31 23:44:52.851 +0900 [INFO] (0001:preview): > 0.00 seconds
2022-07-31 23:44:52.853 +0900 [INFO] (0001:preview): SQL: FETCH FORWARD 10000 FROM cur
2022-07-31 23:44:52.855 +0900 [INFO] (0001:preview): > 0.00 seconds
+---------+-------------+--------------------------------+
| id:long | name:string |           updated_at:timestamp |
+---------+-------------+--------------------------------+
|       1 |      myname | 2022-07-31 05:38:27.367185 UTC |
+---------+-------------+--------------------------------+
```