### PR TITLE
[embulk-input-mysql] Use Latest 5.1.49 JDBC Driver

### DIFF
--- a/embulk-input-mysql/build.gradle
+++ b/embulk-input-mysql/build.gradle
@@ -1,8 +1,8 @@
 dependencies {
     compile(project(path: ":embulk-input-jdbc", configuration: "runtimeElements"))
 
-    compileOnly "mysql:mysql-connector-java:5.1.44"
-    defaultJdbcDriver 'mysql:mysql-connector-java:5.1.44'
+    compileOnly "mysql:mysql-connector-java:5.1.49"
+    defaultJdbcDriver 'mysql:mysql-connector-java:5.1.49'
 
     testCompile "com.google.guava:guava:18.0"
     testCompile "org.embulk:embulk-formatter-csv:0.10.36"
@@ -10,7 +10,7 @@ dependencies {
     testCompile "org.embulk:embulk-output-file:0.10.36"
     testCompile "org.embulk:embulk-parser-csv:0.10.36"
 
-    testCompile "mysql:mysql-connector-java:5.1.44"
+    testCompile "mysql:mysql-connector-java:5.1.49"
 }
 
 embulkPlugin {
@@ -18,7 +18,7 @@ embulkPlugin {
     category = "input"
     type = "mysql"
     additionalDependencyDeclarations = [
-        [ groupId: "mysql", artifactId: "mysql-connector-java", version: "5.1.44", scope: "compile", optional: true ],
+        [ groupId: "mysql", artifactId: "mysql-connector-java", version: "5.1.49", scope: "compile", optional: true ],
     ]
 }
 


### PR DESCRIPTION
Hi @hiroyuki-sato 

I know we would better to switch [Connector/J 8.X](https://github.com/embulk/embulk-input-jdbc/pull/200), prior to that, how about to use latest current JDBC minor version?

Since I'm facing `javax.net.ssl.SSLException: closing inbound before receiving peer's close_notify` error with following combination, I'm wondering whether I need to use later version of JDBC Driver.
* AWS RDS MySQL  5.7.36
* embulk v0.9.17
* embulk-input-mysql (0.10.0)
* JDBC Driver = /home/digdag/.embulk/lib/gems/gems/embulk-input-mysql-0.10.0/default_jdbc_driver/mysql-connector-java-5.1.44.jar

According to this article, it recommend to use more later version of JDBC.
https://tech.omablo.com/archives/1042
https://takeda-san.hatenablog.com/entry/2019/01/24/004526

Therefore I feel better to use latest of 5.1.x series of JDBC Driver as default. that driver are released on Apr 20, 2020. it was 3 years ago.