### PR TITLE
support preview data

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/AbstractJdbcInputPlugin.java
@@ -17,7 +17,6 @@ import java.util.Properties;
 import java.nio.file.Paths;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.time.DateTimeException;
 import java.time.ZoneId;
 import java.util.Optional;
 import java.util.TreeMap;
@@ -501,7 +500,8 @@ public abstract class AbstractJdbcInputPlugin
             }
 
             List<ColumnGetter> getters = newColumnGetters(con, task, querySchema, pageBuilder);
-            try (BatchSelect cursor = con.newSelectCursor(builtQuery, getters, task.getFetchRows(), task.getSocketTimeout())) {
+            try (BatchSelect cursor = con.newSelectCursor(builtQuery, getters, task.getFetchRows(),
+                task.getSocketTimeout(), Exec.isPreview())) {
                 while (true) {
                     long rows = fetch(cursor, getters, pageBuilder);
                     if (rows <= 0L) {

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -123,18 +123,19 @@ public class JdbcInputConnection
         }
     }
 
-    public BatchSelect newSelectCursor(PreparedQuery preparedQuery,
-            List<ColumnGetter> getters,
-            int fetchRows, int queryTimeout) throws SQLException
+    public BatchSelect newSelectCursor(PreparedQuery preparedQuery, List<ColumnGetter> getters, int fetchRows,
+                                       int queryTimeout, boolean isPreview) throws SQLException
     {
-        return newBatchSelect(preparedQuery, getters, fetchRows, queryTimeout);
+        return newBatchSelect(preparedQuery, getters, fetchRows, queryTimeout, isPreview);
     }
 
-    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery,
-            List<ColumnGetter> getters,
-            int fetchRows, int queryTimeout) throws SQLException
+    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery, List<ColumnGetter> getters, int fetchRows,
+                                         int queryTimeout, boolean isPreview) throws SQLException
     {
-        String query = preparedQuery.getQuery();
+        String query = isPreview
+            ? new PreviewQueryBuilder(preparedQuery.getQuery(), connection).build()
+            : preparedQuery.getQuery();
+
         List<JdbcLiteral> params = preparedQuery.getParameters();
 
         PreparedStatement stmt = connection.prepareStatement(query);

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/PreviewQueryBuilder.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/PreviewQueryBuilder.java
@@ -1,0 +1,41 @@
+package org.embulk.input.jdbc;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.util.regex.Pattern;
+
+public class PreviewQueryBuilder
+{
+    private static final String MSSQL_PRODUCT_NAME = "Microsoft SQL Server";
+    private static final String LIMIT_STATEMENT_TEMPLATE = "%s LIMIT 50";
+    private static final String TOP_STATEMENT_TEMPLATE = "%s TOP 50 %s";
+    private static final Pattern SELECT_PATTERN = Pattern.compile("select", Pattern.CASE_INSENSITIVE);
+
+    private String query;
+    private Connection connection;
+
+    public PreviewQueryBuilder(final String query, final Connection connection)
+    {
+        this.query = query;
+        this.connection = connection;
+    }
+
+    public String build() throws SQLException
+    {
+        return isMSSQL()
+            ? buildPreviewSQLForMSSQL()
+            : String.format(LIMIT_STATEMENT_TEMPLATE, this.query);
+    }
+
+    private String buildPreviewSQLForMSSQL()
+    {
+        final String[] statements = SELECT_PATTERN.split(query);
+        return String.format(TOP_STATEMENT_TEMPLATE, "SELECT", statements[1]);
+    }
+
+    protected boolean isMSSQL() throws SQLException
+    {
+        final String productName = connection.getMetaData().getDatabaseProductName();
+        return MSSQL_PRODUCT_NAME.equals(productName);
+    }
+}

--- a/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
+++ b/embulk-input-mysql/src/main/java/org/embulk/input/mysql/MySQLInputConnection.java
@@ -10,6 +10,7 @@ import java.util.TimeZone;
 
 import org.embulk.input.jdbc.JdbcInputConnection;
 import org.embulk.input.jdbc.JdbcLiteral;
+import org.embulk.input.jdbc.PreviewQueryBuilder;
 import org.embulk.input.jdbc.getter.ColumnGetter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -26,11 +27,13 @@ public class MySQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery,
-            List<ColumnGetter> getters,
-            int fetchRows, int queryTimeout) throws SQLException
+    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery, List<ColumnGetter> getters, int fetchRows,
+                                         int queryTimeout, boolean isPreview) throws SQLException
     {
-        String query = preparedQuery.getQuery();
+        String query = isPreview
+            ? new PreviewQueryBuilder(preparedQuery.getQuery(), connection).build()
+            : preparedQuery.getQuery();
+
         List<JdbcLiteral> params = preparedQuery.getParameters();
 
         logger.info("SQL: " + query);

--- a/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
+++ b/embulk-input-postgresql/src/main/java/org/embulk/input/postgresql/PostgreSQLInputConnection.java
@@ -8,6 +8,7 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.Optional;
 
+import org.embulk.input.jdbc.PreviewQueryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.embulk.input.jdbc.JdbcInputConnection;
@@ -27,11 +28,15 @@ public class PostgreSQLInputConnection
     }
 
     @Override
-    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery,
-            List<ColumnGetter> getters,
-            int fetchRows, int queryTimeout) throws SQLException
+    protected BatchSelect newBatchSelect(PreparedQuery preparedQuery, List<ColumnGetter> getters, int fetchRows,
+                                         int queryTimeout, boolean isPreview) throws SQLException
     {
-        String query = "DECLARE cur NO SCROLL CURSOR FOR " + preparedQuery.getQuery();
+        String query = isPreview
+            ? new PreviewQueryBuilder(preparedQuery.getQuery(), connection).build()
+            : preparedQuery.getQuery();
+
+        query = "DECLARE cur NO SCROLL CURSOR FOR " + query;
+
         List<JdbcLiteral> params = preparedQuery.getParameters();
 
         logger.info("SQL: " + query);


### PR DESCRIPTION
Currently, the embulk input jdbc connector fetch all records for preview. This PR will limit to 50 records for generating preview.