### PR TITLE
jdbc: Explicit rollback before closing connections

### DIFF
--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -48,7 +48,6 @@ public class JdbcInputConnection
         if (schemaName != null) {
             setSearchPath(schemaName);
         }
-        connection.setAutoCommit(false);
     }
 
     protected void setSearchPath(String schema) throws SQLException

--- a/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
+++ b/embulk-input-jdbc/src/main/java/org/embulk/input/jdbc/JdbcInputConnection.java
@@ -48,6 +48,7 @@ public class JdbcInputConnection
         if (schemaName != null) {
             setSearchPath(schemaName);
         }
+        connection.setAutoCommit(false);
     }
 
     protected void setSearchPath(String schema) throws SQLException
@@ -204,6 +205,9 @@ public class JdbcInputConnection
     @Override
     public void close() throws SQLException
     {
+        // This is for the JDBC driver that requires an explicit commit or rollback before closing the connection (e.g., DB2).
+        connection.rollback();
+
         connection.close();
     }
 


### PR DESCRIPTION
~~Removed the hardcoded autoCommit setting so that users can set it via YAML configuration like this:~~

<!--
```yaml
in:
  type: jdbc
  options:
    autoCommit: true
```
-->


Added an explicit rollback before closing connections to avoid transaction errors as mentioned [here](https://github.com/embulk/embulk-input-jdbc/pull/258#issuecomment-2123810843).

