### PR TITLE
Add the jTDS built-in driver deprecated message

### DIFF
--- a/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputPlugin.java
+++ b/embulk-input-sqlserver/src/main/java/org/embulk/input/sqlserver/SQLServerInputPlugin.java
@@ -225,6 +225,8 @@ public class SQLServerInputPlugin
         }
 
         if (useJtdsDriver) {
+            logger.warn("The jTDS built-in driver will be removed in an upcoming release.");
+            logger.warn("Please see https://github.com/embulk/embulk-input-jdbc/issues/267");
             // jTDS URL: host:port[/database] or host[/database][;instance=]
             // host:port;instance= is allowed but port will be ignored? in this case.
             if (sqlServerTask.getInstance().isPresent()) {


### PR DESCRIPTION
Relates to  #267. Remove the jTDS built-in driver in an upcoming release.