### PR TITLE
sqlserver plugin supports driver_path option

### DIFF
--- a/embulk-input-sqlserver/build.gradle
+++ b/embulk-input-sqlserver/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
     implementation(project(path: ":embulk-input-jdbc", configuration: "runtimeElements"))
-    implementation "com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8"
+    defaultJdbcDriver "com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8"
     implementation("com.microsoft.azure:adal4j:1.6.7") {
         exclude group: 'org.slf4j', module: 'slf4j-api'
         exclude group: "org.apache.commons", module: "commons-lang3"

--- a/embulk-input-sqlserver/gradle.lockfile
+++ b/embulk-input-sqlserver/gradle.lockfile
@@ -8,7 +8,6 @@ com.fasterxml.jackson.datatype:jackson-datatype-jdk8:2.6.7=compileClasspath,runt
 com.github.stephenc.jcip:jcip-annotations:1.0-1=compileClasspath,runtimeClasspath
 com.google.code.gson:gson:2.8.0=compileClasspath,runtimeClasspath
 com.microsoft.azure:adal4j:1.6.7=compileClasspath,runtimeClasspath
-com.microsoft.sqlserver:mssql-jdbc:7.2.2.jre8=compileClasspath,runtimeClasspath
 com.nimbusds:content-type:2.1=compileClasspath,runtimeClasspath
 com.nimbusds:lang-tag:1.5=compileClasspath,runtimeClasspath
 com.nimbusds:nimbus-jose-jwt:9.8.1=compileClasspath,runtimeClasspath


### PR DESCRIPTION
This PR supports `driver_path` in the sqlserver plugin.
Release to #266 

```
./embulk-0.11.4.jar run config.yml
...
2024-09-12 19:50:01.547 +0900 [INFO] (main): Started Embulk v0.11.4
...
2024-09-12 19:50:04.813 +0900 [INFO] (0001:transaction): Loaded JRuby runtime 9.4.8.0
2024-09-12 19:50:04.933 +0900 [INFO] (0001:transaction): Loaded plugin embulk-input-sqlserver (0.14.0)
2024-09-12 19:50:05.077 +0900 [INFO] (0001:transaction): Loaded plugin embulk-output-stdout
2024-09-12 19:50:05.396 +0900 [WARN] (0001:transaction): "UTC" is recognized as "Z" to be compatible with the legacy style.
...
2024-09-12 19:50:05.694 +0900 [INFO] (0001:transaction): Using JDBC Driver 9.2.1.0
```

## Tesed config

```yaml
in:
  type: sqlserver
  driver_path: /tmp/mssql-jdbc-9.2.1.jre8.jar
  host: 10.10.10.10
  user: user
  password: password
  table: SYSOBJECTS
  database: master
out:
  type: stdout
```